### PR TITLE
Add Discord webhook notifications for new submissions

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -11,6 +11,7 @@ from flask_wtf.csrf import CSRFProtect
 from app.services.database import init_db
 from app.services.session import init_session
 from app.services.recaptcha import init_recaptcha
+from app.services.discord import init_discord
 from app.services.view import register_filters
 
 
@@ -45,6 +46,7 @@ def create_app(config_path=None):
     init_db(app, config['Database'])
     init_session(app, config['Session'])
     init_recaptcha(app, config['Recaptcha'])
+    init_discord(app, config.get('Discord'))
 
     # Register blueprints
     from app.controllers import register_blueprints

--- a/app/controllers/crackme.py
+++ b/app/controllers/crackme.py
@@ -19,6 +19,7 @@ from app.models.errors import ErrNoResult
 from app.services.recaptcha import verify as verify_recaptcha
 from app.services.view import FLASH_ERROR, FLASH_SUCCESS, validate_required
 from app.services.archive import is_archive_password_protected
+from app.services.discord import notify_new_crackme
 from app.controllers.decorators import login_required
 
 crackme_bp = Blueprint('crackme', __name__)
@@ -210,6 +211,12 @@ def upload_crackme_post():
         notification_add(username, f"Crackme '{crackme['name']}' added, waiting for approval!")
     except Exception as e:
         print(f"Notification error: {e}")
+
+    # Send Discord notification
+    try:
+        notify_new_crackme(username, crackme['name'])
+    except Exception as e:
+        print(f"Discord notification error: {e}")
 
     flash('Crackme uploaded! Should be available soon.', FLASH_SUCCESS)
     return redirect(f'/user/{username}')

--- a/app/controllers/solution.py
+++ b/app/controllers/solution.py
@@ -13,6 +13,7 @@ from app.models.errors import ErrNoResult
 from app.services.recaptcha import verify as verify_recaptcha
 from app.services.view import FLASH_ERROR, FLASH_SUCCESS
 from app.services.archive import is_archive_password_protected
+from app.services.discord import notify_new_solution
 from app.controllers.decorators import login_required
 
 solution_bp = Blueprint('solution', __name__)
@@ -118,6 +119,8 @@ def upload_solution_post(hexidcrackme):
     try:
         crackme = crackme_by_hexid(hexidcrackme)
         notification_add(username, f"Your solution for '{crackme['name']}' is waiting approval!")
+        # Send Discord notification
+        notify_new_solution(username, crackme['name'])
     except Exception as e:
         print(f"Notification error: {e}")
 

--- a/app/services/discord.py
+++ b/app/services/discord.py
@@ -1,0 +1,80 @@
+"""
+Discord webhook notification service.
+"""
+
+import requests
+
+# Global Discord configuration
+discord_config = {}
+
+
+def init_discord(app, config):
+    """Initialize Discord configuration."""
+    global discord_config
+    discord_config = config if config else {}
+    app.config['DISCORD_CONFIG'] = discord_config
+
+
+def is_enabled():
+    """Check if Discord notifications are enabled."""
+    return discord_config.get('Enabled', False)
+
+
+def get_webhook_url():
+    """Get the Discord webhook URL."""
+    return discord_config.get('WebhookURL', '')
+
+
+def send_notification(message: str) -> bool:
+    """Send a notification to Discord via webhook.
+
+    Args:
+        message: The message to send
+
+    Returns:
+        True if the notification was sent successfully, False otherwise
+    """
+    if not is_enabled():
+        return True
+
+    webhook_url = get_webhook_url()
+    if not webhook_url:
+        return False
+
+    try:
+        payload = {
+            'content': message
+        }
+        response = requests.post(webhook_url, json=payload, timeout=10)
+        return response.status_code in (200, 204)
+    except Exception as e:
+        print(f"Discord notification error: {e}")
+        return False
+
+
+def notify_new_crackme(username: str, crackme_name: str) -> bool:
+    """Send notification for a new crackme submission.
+
+    Args:
+        username: The user who submitted the crackme
+        crackme_name: The name of the crackme
+
+    Returns:
+        True if notification was sent successfully
+    """
+    message = f"New crackme submission awaiting review: **{crackme_name}** by **{username}**"
+    return send_notification(message)
+
+
+def notify_new_solution(username: str, crackme_name: str) -> bool:
+    """Send notification for a new solution submission.
+
+    Args:
+        username: The user who submitted the solution
+        crackme_name: The name of the crackme that was solved
+
+    Returns:
+        True if notification was sent successfully
+    """
+    message = f"New solution submission awaiting review: Solution for **{crackme_name}** by **{username}**"
+    return send_notification(message)

--- a/config/config.json.example
+++ b/config/config.json.example
@@ -15,5 +15,9 @@
         "Enabled": false,
         "SiteKey": "your-recaptcha-site-key",
         "Secret": "your-recaptcha-secret"
+    },
+    "Discord": {
+        "Enabled": false,
+        "WebhookURL": "your-discord-webhook-url"
     }
 }


### PR DESCRIPTION
## Summary

- Send Discord notifications when new crackmes or solutions are uploaded and await review
- Discord webhook URL is configurable via `config.json` (not hardcoded)
- Notifications can be enabled/disabled via config

## Changes

- **config/config.json.example**: Added `Discord` section with `Enabled` and `WebhookURL` options
- **app/services/discord.py**: New service with:
  - `init_discord()` - Initialize Discord config
  - `is_enabled()` - Check if Discord notifications are enabled
  - `send_notification()` - Send a message via webhook
  - `notify_new_crackme()` - Send notification for new crackme submission
  - `notify_new_solution()` - Send notification for new solution submission
- **app/__init__.py**: Initialize Discord service on app startup
- **app/controllers/crackme.py**: Send Discord notification after crackme upload
- **app/controllers/solution.py**: Send Discord notification after solution upload

## Configuration

Add to your `config.json`:
```json
"Discord": {
    "Enabled": true,
    "WebhookURL": "https://discord.com/api/webhooks/..."
}
```

## Test plan

- [ ] Set `Enabled: false` - verify no Discord notifications are sent
- [ ] Set `Enabled: true` with valid webhook URL - verify notifications are sent
- [ ] Upload a crackme - verify Discord notification appears
- [ ] Upload a solution - verify Discord notification appears
- [ ] Test with invalid webhook URL - verify app doesn't crash (error is logged)

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)