### PR TITLE
Add download count tracking for crackmes

### DIFF
--- a/app/controllers/crackme.py
+++ b/app/controllers/crackme.py
@@ -9,7 +9,7 @@ import bleach
 from app.models.crackme import (
     crackme_by_hexid, last_crackmes, crackme_create_prepare,
     crackme_insert, crackme_delete_by_hexid, crackme_by_user_and_name,
-    crackme_update_difficulty, crackme_update_quality
+    crackme_update_difficulty, crackme_update_quality, crackme_increment_downloads
 )
 from app.models.solution import solutions_by_crackme
 from app.models.comment import comments_by_crackme
@@ -60,6 +60,7 @@ def crackme_view(hexid):
                            comments=comments,
                            nbsolutions=crackme.get('nbsolutions', 0),
                            nbcomments=crackme.get('nbcomments', 0),
+                           nbdownloads=crackme.get('nbdownloads', 0),
                            difficulty=f"{crackme.get('difficulty', 0):.1f}",
                            quality=f"{crackme.get('quality', 0):.1f}")
 
@@ -83,6 +84,29 @@ def last_crackmes_page(page):
                            crackmes=crackmes,
                            prec=prec,
                            next=next_page)
+
+
+@crackme_bp.route('/download/crackme/<hexid>')
+def download_crackme(hexid):
+    """Handle crackme download and track download count."""
+    # Verify crackme exists
+    try:
+        crackme_by_hexid(hexid)
+    except ErrNoResult:
+        abort(404)
+    except Exception as e:
+        print(f"Error getting crackme: {e}")
+        abort(500)
+
+    # Increment download count
+    try:
+        crackme_increment_downloads(hexid)
+    except Exception as e:
+        print(f"Error incrementing download count: {e}")
+        # Continue with download even if count fails
+
+    # Redirect to static file
+    return redirect(f'/static/crackme/{hexid}.zip')
 
 
 @crackme_bp.route('/upload/crackme', methods=['GET'])

--- a/app/models/crackme.py
+++ b/app/models/crackme.py
@@ -102,6 +102,18 @@ def crackme_decrement_comments(crackme_hexid):
     )
 
 
+def crackme_increment_downloads(crackme_hexid):
+    """Increment download count for a crackme."""
+    if not check_connection():
+        raise ErrUnavailable("Database is unavailable")
+
+    collection = get_collection('crackme')
+    collection.update_one(
+        {'hexid': crackme_hexid},
+        {'$inc': {'nbdownloads': 1}}
+    )
+
+
 def search_crackme(name='', author='', lang='', arch='', platform='',
                    difficulty_min=0, difficulty_max=6,
                    quality_min=0, quality_max=6):
@@ -210,6 +222,7 @@ def crackme_create(name, info, username, lang, arch, platform):
         'quality': 0.0,
         'nbsolutions': 0,
         'nbcomments': 0,
+        'nbdownloads': 0,
         'platform': platform
     }
 
@@ -239,6 +252,7 @@ def crackme_create_prepare(name, info, username, lang, arch, platform):
         'quality': 0.0,
         'nbsolutions': 0,
         'nbcomments': 0,
+        'nbdownloads': 0,
         'platform': platform
     }
 

--- a/templates/crackme/read.html
+++ b/templates/crackme/read.html
@@ -26,7 +26,8 @@
         <div class="column col-1">
         </div>
         <div class="column col-2" style="padding-right: 0rem">
-            <a href="/static/crackme/{{ hexid }}.zip" class="btn active btn-lg btn-download">Download</a>
+            <a href="/download/crackme/{{ hexid }}" class="btn active btn-lg btn-download">Download</a>
+            <p style="text-align: center; margin-top: 5px; font-size: 0.8em;">{{ nbdownloads }} downloads</p>
         </div>
 
         <div class="column col-3">


### PR DESCRIPTION
## Summary

Implements download count tracking for crackmes, allowing users to see how popular each crackme is.

## Changes

### Model (`app/models/crackme.py`)
- Added `nbdownloads` field to crackme document (initialized to 0 for new crackmes)
- Added `crackme_increment_downloads(hexid)` function to atomically increment the counter

### Controller (`app/controllers/crackme.py`)
- Added new route `/download/crackme/<hexid>` that:
  1. Verifies the crackme exists
  2. Increments the download counter
  3. Redirects to the static file `/static/crackme/<hexid>.zip`
- Updated `crackme_view` to pass `nbdownloads` to the template

### Template (`templates/crackme/read.html`)
- Changed download button to use new `/download/crackme/<hexid>` route
- Added download count display below the download button

## Notes

- Existing crackmes without the `nbdownloads` field will display 0 (uses `.get('nbdownloads', 0)`)
- Download count increment failures are logged but don't prevent the download
- The counter uses MongoDB's atomic `$inc` operator for accurate counting

## Test plan

- [ ] Visit a crackme page - verify download count is displayed
- [ ] Click download button - verify file downloads correctly
- [ ] Refresh crackme page - verify download count incremented by 1
- [ ] Test with invalid hexid - verify 404 error

Fixes https://github.com/crackmesone/crackmes.one/issues/34

🤖 Generated with [Claude Code](https://claude.com/claude-code)