### PR TITLE
Add prominent Submit a writeup button

### DIFF
--- a/templates/crackme/read.html
+++ b/templates/crackme/read.html
@@ -94,7 +94,7 @@
         </div>
         <div class="column col-12" id="solutions" style="display:none">
             {% if AuthLevel == "auth" %}
-            <p>You want to share your writeup ? Please follow this <b><a href="/upload/solution/{{ hexid }}">link</a></b> and check the instructions !</p>
+            <a href="/upload/solution/{{ hexid }}" class="btn active float-right" style="margin-top:-65px;">Submit a writeup</a>
             {% else %}
             <p>You must be logged in to submit a writeup</p>
             {% endif %}


### PR DESCRIPTION
## Summary
- Replace the text link "Please follow this link" with a styled button for submitting writeups
- The new "Submit a writeup" button matches the style of the existing "Post a comment" button
- Makes the writeup submission process more discoverable for users

Fixes crackmesone/crackmes.one#71

## Before
The writeup section showed a paragraph with an embedded link:
> You want to share your writeup ? Please follow this **link** and check the instructions !

## After
The writeup section now shows a prominent button matching the comment button style:
> [Submit a writeup] (button)

## Test plan
- [ ] Navigate to a crackme detail page while logged in
- [ ] Click on the "Writeups" tab
- [ ] Verify the "Submit a writeup" button appears in the same position as "Post a comment" on the Comments tab
- [ ] Click the button and verify it navigates to the upload solution page

🤖 Generated with [Claude Code](https://claude.com/claude-code)