### PR TITLE
Fix unread notification count not updating on approve/reject

### DIFF
--- a/script/delete.py
+++ b/script/delete.py
@@ -70,6 +70,7 @@ else:
 if send_notif:
     print("[+] Sending " + type_object + " rejection notification!")
     notif_coll = db.notifications
+    users_coll = db.user
     author_name = db_object["author"]
     if type_object == "solution":
         crackme_obj = db.crackme.find_one({'_id': db_object["crackmeid"]})
@@ -94,3 +95,4 @@ if send_notif:
         }).inserted_id
     # Set HexId here
     notif_coll.find_one_and_update({'_id': ins_id}, {'$set': {'hexid': str(ins_id)}})
+    users_coll.update_one({'name': author_name}, {'$inc': {'unread_notifications': 1}})

--- a/script/validate.py
+++ b/script/validate.py
@@ -69,6 +69,7 @@ if send_notif:
     print("[+] Sending " + type_object + " approval notification!")
     notif_coll = db.notifications
     author_name = db_object["author"]
+    users_coll = db.user
     if type_object == "solution":
         crackme_obj = db.crackme.find_one({'_id': db_object["crackmeid"]})
         ins_id = notif_coll.insert_one({
@@ -79,13 +80,17 @@ if send_notif:
         }).inserted_id
         # Set HexId here too for this case
         notif_coll.find_one_and_update({'_id': ins_id}, {'$set': {'hexid': str(ins_id)}})
+        users_coll.update_one({'name': author_name}, {'$inc': {'unread_notifications': 1}})
         # Notify crackme author about new solution
+        crackme_author = crackme_obj["author"]
         ins_id = notif_coll.insert_one({
-            "user": crackme_obj["author"],
+            "user": crackme_author,
             "time": datetime.datetime.now(datetime.timezone.utc),
             "seen": False,
             "text": "A new solution for your crackme '" + crackme_obj["name"] + "' has been submitted by: " + author_name
         }).inserted_id
+        notif_coll.find_one_and_update({'_id': ins_id}, {'$set': {'hexid': str(ins_id)}})
+        users_coll.update_one({'name': crackme_author}, {'$inc': {'unread_notifications': 1}})
     elif type_object == "crackme":
         ins_id = notif_coll.insert_one({
             "user": author_name,
@@ -93,5 +98,6 @@ if send_notif:
             "seen": False,
             "text": "Your crackme '" + db_object["name"] + "' has been accepted!"
         }).inserted_id
-    # Set HexId here
-    notif_coll.find_one_and_update({'_id': ins_id}, {'$set': {'hexid': str(ins_id)}})
+        # Set HexId here
+        notif_coll.find_one_and_update({'_id': ins_id}, {'$set': {'hexid': str(ins_id)}})
+        users_coll.update_one({'name': author_name}, {'$inc': {'unread_notifications': 1}})


### PR DESCRIPTION
## Summary

Fixes #11

- Update `validate.py` to increment `unread_notifications` count when approving crackmes/solutions
- Update `delete.py` to increment `unread_notifications` count when rejecting crackmes/solutions
- Also fixes missing hexid and count increment for the crackme author notification when a solution is approved

## Test plan

- [ ] Approve a crackme and verify the author sees the notification badge update
- [ ] Approve a solution and verify both the solution author and crackme author see badge updates
- [ ] Reject a submission and verify the author sees the notification badge update

🤖 Generated with [Claude Code](https://claude.com/claude-code)