### PR TITLE
Add Discord notification for new comments

### DIFF
--- a/app/controllers/comment.py
+++ b/app/controllers/comment.py
@@ -9,6 +9,7 @@ from app.models.crackme import crackme_by_hexid, crackme_increment_comments
 from app.models.notification import notification_add
 from app.models.errors import ErrNoResult
 from app.services.recaptcha import verify as verify_recaptcha
+from app.services.discord import notify_new_comment
 from app.services.view import FLASH_ERROR, FLASH_SUCCESS, validate_required
 from app.controllers.decorators import login_required
 
@@ -48,7 +49,7 @@ def leave_comment(hexid):
     except Exception as e:
         print(f"Failed to increment comment count: {e}")
 
-    # Send notification to crackme author
+    # Send notification to crackme author and Discord
     try:
         crackme = crackme_by_hexid(hexid)
         if crackme.get('author') != username:
@@ -56,6 +57,8 @@ def leave_comment(hexid):
                 crackme['author'],
                 f"New comment on your crackme '{crackme['name']}' by: {username}"
             )
+        # Send Discord moderation notification
+        notify_new_comment(username, crackme['name'], hexid, comment_text)
     except Exception as e:
         print(f"Notification error: {e}")
 

--- a/app/services/discord.py
+++ b/app/services/discord.py
@@ -1,9 +1,10 @@
 """
 Discord webhook notification service.
 
-Two webhooks are supported:
+Three webhooks are supported:
 - WebhookPublic: Public channel for approved crackmes/solutions notifications
 - WebhookPrivate: Private/admin channel for pending submissions and reviewer logs
+- WebhookModeration: Moderation channel for user activity (comments, etc.)
 """
 
 import datetime
@@ -34,6 +35,11 @@ def get_public_webhook():
 def get_private_webhook():
     """Get the private Discord webhook URL (for pending items and logs)."""
     return discord_config.get('WebhookPrivate', '')
+
+
+def get_moderation_webhook():
+    """Get the moderation Discord webhook URL (for user activity like comments)."""
+    return discord_config.get('WebhookModeration', '')
 
 
 def send_to_webhook(webhook_url: str, message: str = None, embed: dict = None) -> bool:
@@ -176,3 +182,74 @@ def notify_new_solution(username: str, crackme_name: str) -> bool:
         }
     )
     return send_private_notification(embed=embed)
+
+
+def send_moderation_notification(embed: dict) -> bool:
+    """Send a notification to the moderation Discord channel.
+
+    Args:
+        embed: The embed object to send
+
+    Returns:
+        True if the notification was sent successfully, False otherwise
+    """
+    if not is_enabled():
+        return True
+    return send_to_webhook(get_moderation_webhook(), embed=embed)
+
+
+def notify_new_comment(username: str, crackme_name: str, crackme_hexid: str,
+                       comment_text: str) -> bool:
+    """Send notification for a new comment posted.
+
+    Sent to MODERATION channel for monitoring user activity.
+
+    Args:
+        username: The user who posted the comment
+        crackme_name: The name of the crackme
+        crackme_hexid: The hexid of the crackme (for link)
+        comment_text: The comment content
+
+    Returns:
+        True if notification was sent successfully
+    """
+    timestamp = (
+        datetime.datetime.utcnow()
+        .replace(tzinfo=timezone.utc)
+        .isoformat(timespec='milliseconds')
+        .replace('+00:00', 'Z')
+    )
+
+    # Cyan/teal color for comments
+    color = 65535
+
+    # Truncate comment if too long
+    truncated_comment = comment_text[:500] + "..." if len(comment_text) > 500 else comment_text
+
+    embed = {
+        "title": "New Comment Posted",
+        "description": f"A new comment has been posted on crackmes.one",
+        "color": color,
+        "fields": [
+            {
+                "name": "Challenge",
+                "value": f"[{crackme_name}](https://crackmes.one/crackme/{crackme_hexid})",
+                "inline": True
+            },
+            {
+                "name": "Author",
+                "value": f"[{username}](https://crackmes.one/user/{username})",
+                "inline": True
+            },
+            {
+                "name": "Comment",
+                "value": truncated_comment,
+                "inline": False
+            }
+        ],
+        "footer": {
+            "text": "CrackMes.One",
+        },
+        "timestamp": timestamp,
+    }
+    return send_moderation_notification(embed)

--- a/config/config.json.example
+++ b/config/config.json.example
@@ -19,7 +19,8 @@
     "Discord": {
         "Enabled": false,
         "WebhookPublic": "your-public-discord-webhook-url",
-        "WebhookPrivate": "your-private-discord-webhook-url"
+        "WebhookPrivate": "your-private-discord-webhook-url",
+        "WebhookModeration": "your-moderation-discord-webhook-url"
     },
     "Reviewer": {
         "Enabled": false,


### PR DESCRIPTION
## Summary
- Add a new Discord webhook (WebhookModeration) for user activity monitoring
- Send Discord notification when a comment is posted on a crackme

## Changes
- `app/services/discord.py`:
  - Add `get_moderation_webhook()` function
  - Add `send_moderation_notification()` function
  - Add `notify_new_comment()` function with embed including:
    - Challenge name with link
    - Author name with link
    - Comment content (truncated to 500 chars if needed)
    - Cyan/teal color (65535) to distinguish from other notifications
- `app/controllers/comment.py`: Call `notify_new_comment()` after comment creation
- `config/config.json.example`: Add WebhookModeration field

## Configuration
Add to your `config.json`:
```json
"Discord": {
    "WebhookModeration": "your-moderation-discord-webhook-url"
}
```

## Test plan
- [ ] Post a comment on a crackme
- [ ] Verify Discord notification appears in the moderation channel
- [ ] Verify embed contains challenge link, author link, and comment text

Fixes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)