### PR TITLE
Automatically reject PE file solution submissions

### DIFF
--- a/app/controllers/solution.py
+++ b/app/controllers/solution.py
@@ -12,7 +12,7 @@ from app.models.notification import notification_add
 from app.models.errors import ErrNoResult
 from app.services.recaptcha import verify as verify_recaptcha
 from app.services.view import FLASH_ERROR, FLASH_SUCCESS
-from app.services.archive import is_archive_password_protected
+from app.services.archive import is_archive_password_protected, is_pe_file
 from app.services.discord import notify_new_solution
 from app.controllers.decorators import login_required
 
@@ -90,6 +90,12 @@ def upload_solution_post(hexidcrackme):
     # Check for password-protected archives
     if is_archive_password_protected(data):
         flash('Password-protected archives are not allowed. Do NOT add a password yourself - the server handles this automatically.', FLASH_ERROR)
+        return redirect(f'/upload/solution/{hexidcrackme}')
+
+    # Check for PE files (patched binaries are not allowed)
+    if is_pe_file(file.filename, data):
+        flash('Executable files (PE binaries) are not allowed as solutions. '
+              'Please submit a writeup that analyzes the algorithm instead of a patched binary.', FLASH_ERROR)
         return redirect(f'/upload/solution/{hexidcrackme}')
 
     # Create solution

--- a/app/services/archive.py
+++ b/app/services/archive.py
@@ -4,6 +4,57 @@ Archive service for validating uploaded archive files.
 
 import zipfile
 import io
+import struct
+
+# PE file extensions (case-insensitive)
+PE_EXTENSIONS = {'.exe', '.dll', '.sys', '.scr', '.ocx', '.com', '.drv', '.cpl', '.efi'}
+
+
+def is_pe_file(filename: str, file_data: bytes) -> bool:
+    """Check if a file is a Windows PE (Portable Executable) file.
+
+    Checks both the file extension and the PE header magic bytes.
+
+    Args:
+        filename: The name of the file (used for extension check)
+        file_data: The binary content of the file
+
+    Returns:
+        True if the file appears to be a PE file, False otherwise
+    """
+    # Check file extension
+    if filename:
+        ext = filename.lower()
+        # Get extension (handle files like "file.exe" or just check suffix)
+        dot_idx = ext.rfind('.')
+        if dot_idx != -1:
+            ext = ext[dot_idx:]
+            if ext in PE_EXTENSIONS:
+                return True
+
+    # Check PE header magic bytes
+    if len(file_data) < 64:
+        return False
+
+    # Check for DOS MZ header
+    if file_data[0:2] != b'MZ':
+        return False
+
+    # Get PE header offset from DOS header (at offset 0x3C)
+    try:
+        pe_offset = struct.unpack('<I', file_data[0x3C:0x40])[0]
+
+        # Check if PE offset is reasonable
+        if pe_offset < 64 or pe_offset > len(file_data) - 4:
+            return False
+
+        # Check for PE signature
+        if file_data[pe_offset:pe_offset + 4] == b'PE\x00\x00':
+            return True
+    except (struct.error, IndexError):
+        pass
+
+    return False
 
 
 def is_archive_password_protected(file_data: bytes) -> bool:


### PR DESCRIPTION
## Summary
Automatically reject solution submissions that are Windows PE executables (patched binaries), directing users to submit writeups instead.

## Changes
- `app/services/archive.py`: Add `is_pe_file()` function that detects PE files by:
  - File extension (.exe, .dll, .sys, .scr, .ocx, .com, .drv, .cpl, .efi)
  - PE header magic bytes (MZ header at offset 0, PE signature at offset from 0x3C)
- `app/controllers/solution.py`: Add PE file check before accepting solution uploads

## User-facing message
> Executable files (PE binaries) are not allowed as solutions. Please submit a writeup that analyzes the algorithm instead of a patched binary.

## Test plan
- [ ] Try uploading a .exe file as a solution - should be rejected
- [ ] Try uploading a .dll file as a solution - should be rejected
- [ ] Try uploading a valid PE file with a different extension - should be rejected (header check)
- [ ] Try uploading a .txt or .pdf writeup - should be accepted
- [ ] Try uploading a .zip containing a writeup - should be accepted

Fixes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)