### PR TITLE
Add account registration time to user lookup page

### DIFF
--- a/review/routes.py
+++ b/review/routes.py
@@ -1945,11 +1945,20 @@ def lookupuser(current_user):
             if user:
                 username = user.get("name")
                 db = g_crackmesone_db
+
+                # Extract registration time from ObjectId
+                registration_time = None
+                if user.get("_id"):
+                    try:
+                        registration_time = user["_id"].generation_time
+                    except Exception:
+                        pass
+
                 user_info = {
                     'username': username,
                     'email': user.get("email"),
                     'is_admin': user.get("is_admin", False),
-                    'created_at': user.get("created_at", "Unknown"),
+                    'registration_time': registration_time,
                     'crackmes_count': db.crackme.count_documents({"author": username}),
                     'solutions_count': db.solution.count_documents({"author": username}),
                     'comments_count': db.comment.count_documents({"author": username}),

--- a/review/templates/reviewer/lookupuser.html
+++ b/review/templates/reviewer/lookupuser.html
@@ -114,7 +114,13 @@
 
             <div class="info-row">
                 <div class="info-label">Account Created:</div>
-                <div class="info-value">{{ user_info.created_at }}</div>
+                <div class="info-value">
+                    {% if user_info.registration_time %}
+                    {{ user_info.registration_time.strftime('%Y-%m-%d %H:%M:%S UTC') }}
+                    {% else %}
+                    Unknown
+                    {% endif %}
+                </div>
             </div>
 
             <hr style="margin: 20px 0;">


### PR DESCRIPTION
## Summary
Display account registration time in the admin user lookup page by extracting the timestamp from the MongoDB ObjectId.

## How it works
MongoDB ObjectIds contain an embedded timestamp in their first 4 bytes, representing when the document was created. The `ObjectId.generation_time` property returns this as a datetime object.

## Changes
- `review/routes.py`: Extract `registration_time` from `user["_id"].generation_time`
- `review/templates/reviewer/lookupuser.html`: Display registration time formatted as `YYYY-MM-DD HH:MM:SS UTC`

## Test plan
- [ ] Look up a user in the admin panel
- [ ] Verify "Account Created" shows the registration timestamp
- [ ] Verify format is readable (e.g., "2024-01-15 10:30:45 UTC")

Fixes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)