### PR TITLE
Add Show All Data option to user lookup page

### DIFF
--- a/review/routes.py
+++ b/review/routes.py
@@ -2018,16 +2018,25 @@ def _fetch_all_user_data(db, username):
         Dictionary containing all user data with URLs
     """
     # Fetch crackmes
-    crackmes = list(db.crackme.find(
+    crackmes_raw = list(db.crackme.find(
         {"author": username},
-        {"hexid": 1, "name": 1, "visible": 1, "date": 1}
-    ).sort("date", -1))
+        {"hexid": 1, "name": 1, "visible": 1, "created_at": 1}
+    ).sort("created_at", -1))
+
+    crackmes = []
+    for cm in crackmes_raw:
+        crackmes.append({
+            "hexid": cm.get("hexid"),
+            "name": cm.get("name"),
+            "visible": cm.get("visible", False),
+            "date": cm.get("created_at")
+        })
 
     # Fetch solutions with crackme info
     solutions_raw = list(db.solution.find(
         {"author": username},
-        {"hexid": 1, "crackmeid": 1, "visible": 1, "date": 1}
-    ).sort("date", -1))
+        {"hexid": 1, "crackmeid": 1, "visible": 1, "created_at": 1}
+    ).sort("created_at", -1))
 
     solutions = []
     for sol in solutions_raw:
@@ -2040,69 +2049,72 @@ def _fetch_all_user_data(db, username):
             "crackme_hexid": crackme.get("hexid") if crackme else None,
             "crackme_name": crackme.get("name") if crackme else "Unknown",
             "visible": sol.get("visible", False),
-            "date": sol.get("date")
+            "date": sol.get("created_at")
         })
 
     # Fetch comments with crackme info
     comments_raw = list(db.comment.find(
         {"author": username},
-        {"hexidcrackme": 1, "comment": 1, "date": 1}
-    ).sort("date", -1))
+        {"crackmehexid": 1, "info": 1, "created_at": 1}
+    ).sort("created_at", -1))
 
     comments = []
     for comm in comments_raw:
         crackme = db.crackme.find_one(
-            {"hexid": comm.get("hexidcrackme")},
+            {"hexid": comm.get("crackmehexid")},
             {"name": 1}
         )
+        comment_text = comm.get("info", "")
         comments.append({
-            "crackme_hexid": comm.get("hexidcrackme"),
+            "crackme_hexid": comm.get("crackmehexid"),
             "crackme_name": crackme.get("name") if crackme else "Unknown",
-            "comment": comm.get("comment", "")[:100] + ("..." if len(comm.get("comment", "")) > 100 else ""),
-            "date": comm.get("date")
+            "comment": comment_text[:100] + ("..." if len(comment_text) > 100 else ""),
+            "date": comm.get("created_at")
         })
 
-    # Fetch difficulty ratings
+    # Fetch difficulty ratings with crackme info
     diff_ratings_raw = list(db.rating_difficulty.find(
         {"author": username},
-        {"crackmeid": 1, "value": 1}
-    ))
+        {"crackmehexid": 1, "rating": 1, "created_at": 1}
+    ).sort("created_at", -1))
 
     diff_ratings = []
     for rating in diff_ratings_raw:
         crackme = db.crackme.find_one(
-            {"_id": rating.get("crackmeid")},
-            {"hexid": 1, "name": 1}
+            {"hexid": rating.get("crackmehexid")},
+            {"name": 1}
         )
         diff_ratings.append({
-            "crackme_hexid": crackme.get("hexid") if crackme else None,
+            "crackme_hexid": rating.get("crackmehexid"),
             "crackme_name": crackme.get("name") if crackme else "Unknown",
-            "value": rating.get("value")
+            "value": rating.get("rating"),
+            "date": rating.get("created_at")
         })
 
-    # Fetch quality ratings
+    # Fetch quality ratings with crackme info
     qual_ratings_raw = list(db.rating_quality.find(
         {"author": username},
-        {"crackmeid": 1, "value": 1}
-    ))
+        {"crackmehexid": 1, "rating": 1, "created_at": 1}
+    ).sort("created_at", -1))
 
     qual_ratings = []
     for rating in qual_ratings_raw:
         crackme = db.crackme.find_one(
-            {"_id": rating.get("crackmeid")},
-            {"hexid": 1, "name": 1}
+            {"hexid": rating.get("crackmehexid")},
+            {"name": 1}
         )
         qual_ratings.append({
-            "crackme_hexid": crackme.get("hexid") if crackme else None,
+            "crackme_hexid": rating.get("crackmehexid"),
             "crackme_name": crackme.get("name") if crackme else "Unknown",
-            "value": rating.get("value")
+            "value": rating.get("rating"),
+            "date": rating.get("created_at")
         })
 
-    # Fetch notifications
+    # Fetch all notifications (no limit)
     notifications = list(db.notifications.find(
         {"user": username},
         {"text": 1, "time": 1, "seen": 1}
-    ).sort("time", -1).limit(50))
+    ).sort("time", -1))
 
     return {
         "crackmes": crackmes,

--- a/review/templates/reviewer/lookupuser.html
+++ b/review/templates/reviewer/lookupuser.html
@@ -68,7 +68,7 @@
         .data-table th {
             text-align: left;
             padding: 8px;
-            background: #f0f0f0;
+            font-weight: bold;
         }
         .data-table td {
             padding: 8px;
@@ -125,7 +125,7 @@
                 <div class="col-3"></div>
                 <div class="col-9 col-sm-12">
                     <button type="submit" class="btn btn-primary" onclick="document.getElementById('show_all_input').value='0'">Lookup User</button>
-                    <button type="submit" class="btn btn-secondary" onclick="document.getElementById('show_all_input').value='1'">Show All Data</button>
+                    <button type="submit" class="btn btn-primary" onclick="document.getElementById('show_all_input').value='1'">Show All Data</button>
                 </div>
             </div>
         </form>
@@ -319,6 +319,7 @@
                     <tr>
                         <th>Crackme</th>
                         <th>Rating</th>
+                        <th>Date</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -332,6 +333,7 @@
                             {% endif %}
                         </td>
                         <td>{{ rating.value }}</td>
+                        <td>{{ rating.date.strftime('%Y-%m-%d %H:%M') if rating.date else 'N/A' }}</td>
                     </tr>
                     {% endfor %}
                 </tbody>
@@ -350,6 +352,7 @@
                     <tr>
                         <th>Crackme</th>
                         <th>Rating</th>
+                        <th>Date</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -363,6 +366,7 @@
                             {% endif %}
                         </td>
                         <td>{{ rating.value }}</td>
+                        <td>{{ rating.date.strftime('%Y-%m-%d %H:%M') if rating.date else 'N/A' }}</td>
                     </tr>
                     {% endfor %}
                 </tbody>
@@ -374,7 +378,7 @@
 
         <!-- Notifications Section -->
         <div class="data-section">
-            <div class="data-section-header">Notifications (showing up to 50 most recent)</div>
+            <div class="data-section-header">Notifications ({{ all_data.notifications|length }})</div>
             {% if all_data.notifications %}
             <table class="data-table">
                 <thead>


### PR DESCRIPTION
## Summary
Adds a "Show All Data" button to the admin user lookup page that displays all data associated with a user, with proper URLs to crackmes.one.

## Features
- **Two buttons**: Both styled as primary buttons for consistency
- **Crackmes**: Name (linked), date, visibility status
- **Solutions**: Crackme name (linked), date, visibility status
- **Comments**: Crackme name (linked), comment text (truncated to 100 chars), date
- **Difficulty Ratings**: Crackme name (linked), rating value, date
- **Quality Ratings**: Crackme name (linked), rating value, date
- **Notifications**: Message text, time, seen/unseen status (all notifications, no limit)

## UI Improvements
- Color-coded status indicators (green=visible, orange=hidden, blue=unseen)
- All crackme references are clickable links
- Username links to user profile on crackmes.one
- Data sections with clear headers showing item counts
- Clean table headers without backgrounds for better visibility

## Fixes in Latest Commit
- Fixed button styling (both buttons now btn-primary)
- Fixed database field name mismatches (created_at, crackmehexid, info, rating)
- Added Date column to ratings tables
- Removed 50-item limit on notifications

## Test plan
- [ ] Look up a user with "Lookup User" - shows summary only
- [ ] Look up a user with "Show All Data" - shows all detailed tables
- [ ] Verify crackmes show name, date, and visibility status correctly
- [ ] Verify solutions show crackme name, date, and visibility status
- [ ] Verify comments show crackme, comment text, and date
- [ ] Verify ratings show crackme, value, and date
- [ ] Verify all notifications are shown (no 50 limit)
- [ ] Click on crackme links - should open in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)