### PR TITLE
Add clickable links to notifications

### DIFF
--- a/app/controllers/comment.py
+++ b/app/controllers/comment.py
@@ -3,6 +3,7 @@ Comment controller - Posting comments.
 """
 
 import re
+from html import escape as html_escape
 from flask import Blueprint, request, redirect, flash, session
 import bleach
 from app.models.comment import comment_create, comment_by_id, comment_set_spoiler, get_thread_participants
@@ -80,7 +81,7 @@ def leave_comment(hexid):
         if crackme_author != username:
             notification_add(
                 crackme_author,
-                f"New comment on your crackme '{crackme_name}' by: {username}"
+                f"New comment on your crackme '<a href=\"/crackme/{hexid}\">{html_escape(crackme_name)}</a>' by: <a href=\"/user/{html_escape(username)}\">{html_escape(username)}</a>"
             )
 
         # Handle @mentions
@@ -103,7 +104,7 @@ def leave_comment(hexid):
                 if mentioned_user in valid_targets:
                     notification_add(
                         mentioned_user,
-                        f"You were mentioned by {username} in a comment on '{crackme_name}'"
+                        f"You were mentioned by <a href=\"/user/{html_escape(username)}\">{html_escape(username)}</a> in a comment on '<a href=\"/crackme/{hexid}\">{html_escape(crackme_name)}</a>'"
                     )
 
         # Send Discord moderation notification

--- a/app/controllers/crackme.py
+++ b/app/controllers/crackme.py
@@ -3,6 +3,7 @@ Crackme controller - Crackme viewing and uploading.
 """
 
 import os
+from html import escape as html_escape
 from flask import Blueprint, render_template, request, redirect, flash, session, abort
 from werkzeug.utils import secure_filename
 import bleach
@@ -252,7 +253,7 @@ def upload_crackme_post():
 
     # Send notification
     try:
-        notification_add(username, f"Crackme '{crackme['name']}' added, waiting for approval!")
+        notification_add(username, f"Crackme '{html_escape(crackme['name'])}' added, waiting for approval!")
     except Exception as e:
         print(f"Notification error: {e}")
 
@@ -335,7 +336,7 @@ def edit_crackme_post(hexid):
     if changes:
         # Send notification to the author about the edit
         try:
-            notification_add(username, f"Your crackme '{crackme.get('name')}' has been updated.")
+            notification_add(username, f"Your crackme '<a href=\"/crackme/{hexid}\">{html_escape(crackme.get('name'))}</a>' has been updated.")
         except Exception as e:
             print(f"Notification error: {e}")
 

--- a/app/controllers/solution.py
+++ b/app/controllers/solution.py
@@ -3,6 +3,7 @@ Solution controller - Solution uploading.
 """
 
 import os
+from html import escape as html_escape
 from flask import Blueprint, render_template, request, redirect, flash, session, abort
 from werkzeug.utils import secure_filename
 import bleach
@@ -126,7 +127,7 @@ def upload_solution_post(hexidcrackme):
     # Send notification
     try:
         crackme = crackme_by_hexid(hexidcrackme)
-        notification_add(username, f"Your solution for '{crackme['name']}' is waiting approval!")
+        notification_add(username, f"Your solution for '{html_escape(crackme['name'])}' is waiting approval!")
         # Send Discord notification
         notify_new_solution(username, crackme['name'])
     except Exception as e:

--- a/review/routes.py
+++ b/review/routes.py
@@ -13,6 +13,7 @@ from flask import (
     url_for, abort, send_file, session
 )
 from functools import wraps
+from html import escape as html_escape
 import datetime
 from datetime import timezone
 import hashlib
@@ -759,9 +760,9 @@ def reject_pending_crackme(file_loc, reject_reason=None):
             os.remove(file_path)
 
         # Notify author
-        notif_text = f"Your crackme '{crackme['name']}' has been rejected!"
+        notif_text = f"Your crackme '{html_escape(crackme['name'])}' has been rejected!"
         if reject_reason:
-            notif_text += f" Reason: {reject_reason}"
+            notif_text += f" Reason: {html_escape(reject_reason)}"
         send_user_notification(crackme["author"], notif_text)
 
         return True, f"Crackme '{crackme['name']}' rejected successfully"
@@ -810,9 +811,9 @@ def reject_pending_solution(file_loc, reject_reason=None):
             os.remove(file_path)
 
         # Notify author
-        notif_text = f"Your solution for '{crackme_name}' has been rejected!"
+        notif_text = f"Your solution for '{html_escape(crackme_name)}' has been rejected!"
         if reject_reason:
-            notif_text += f" Reason: {reject_reason}"
+            notif_text += f" Reason: {html_escape(reject_reason)}"
         send_user_notification(solution["author"], notif_text)
 
         return True, f"Solution for '{crackme_name}' rejected successfully"
@@ -872,7 +873,7 @@ def approve_pending_crackme(file_loc):
         # Notify author
         send_user_notification(
             crackme["author"],
-            f"Your crackme '{crackme['name']}' has been accepted!"
+            f"Your crackme '<a href=\"/crackme/{crackme['hexid']}\">{html_escape(crackme['name'])}</a>' has been accepted!"
         )
 
         return True, f"Crackme '{crackme['name']}' approved successfully"
@@ -940,14 +941,14 @@ def approve_pending_solution(file_loc):
         # Notify solution author
         send_user_notification(
             solution["author"],
-            f"Your solution for '{crackme_name}' has been accepted!"
+            f"Your solution for '<a href=\"/crackme/{crackme['hexid']}\">{html_escape(crackme_name)}</a>' has been accepted!"
         )
 
         # Notify crackme author
         send_user_notification(
             crackme["author"],
-            f"A new solution for your crackme '{crackme_name}' "
-            f"has been submitted by: {solution['author']}"
+            f"A new solution for your crackme '<a href=\"/crackme/{crackme['hexid']}\">{html_escape(crackme_name)}</a>' "
+            f"has been submitted by: <a href=\"/user/{html_escape(solution['author'])}\">{html_escape(solution['author'])}</a>"
         )
 
         return True, f"Solution for '{crackme_name}' approved successfully"
@@ -1928,7 +1929,7 @@ def editcrackme(current_user):
                                 change_summary += f" and {len(changes) - 3} more"
                             send_user_notification(
                                 crackme_obj['author'],
-                                f"Your crackme '{crackme_obj.get('name')}' has been updated by an admin: {change_summary}"
+                                f"Your crackme '<a href=\"/crackme/{crackme_obj.get('hexid')}\">{html_escape(crackme_obj.get('name'))}</a>' has been updated by an admin: {html_escape(change_summary)}"
                             )
                         except Exception as e:
                             print(f"Notification error: {e}")

--- a/templates/notifs/notifs.html
+++ b/templates/notifs/notifs.html
@@ -20,7 +20,7 @@
         {% endif %}
         <div data-id="{{ notif.hexid }}" class="text-center notif-item s-rounded{% if not notif.seen %} active{% endif %}">
             <span class="notif-time text-gray">{{ notif.time|PRETTYTIMEFORMAT("%H:%M") }}</span>
-            <span>{{ notif.text }}</span>
+            <span>{{ notif.text|safe }}</span>
             <i class="icon {% if not notif.seen %}icon-check notif-mark-read{% else %}icon-cross notif-delete{% endif %}"></i>
         </div>
     {% endfor %}


### PR DESCRIPTION
## Summary
- Add clickable links to notification text for crackme names and usernames
- Only add URLs to acceptance notifications (crackme already visible)
- "Waiting for approval" and rejection notifications don't include URLs since the content isn't publicly visible yet
- HTML-escape all user-provided content to prevent XSS when using `|safe` filter

## Changes
- **app/controllers/comment.py**: Escape crackme name and username in comment notifications
- **app/controllers/crackme.py**: Escape crackme name, add URL to edit notification (no URL for "waiting approval")
- **app/controllers/solution.py**: Escape crackme name (no URL for "waiting approval")
- **review/routes.py**: Add URLs and escaping to acceptance/rejection/admin-edit notifications
- **templates/notifs/notifs.html**: Add `|safe` filter to render HTML links

## Test plan
- [ ] Post a comment on a crackme - author should receive notification with clickable links
- [ ] Submit a crackme - notification should NOT have URL (waiting approval)
- [ ] Accept a crackme in review - notification should have clickable URL
- [ ] Reject a crackme in review - notification should NOT have URL
- [ ] Edit a crackme as admin - notification should have clickable URL
- [ ] Verify no XSS possible with malicious crackme names or usernames

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)