### PR TITLE
Added login_redirect cookie

### DIFF
--- a/app/controllers/login.py
+++ b/app/controllers/login.py
@@ -25,8 +25,9 @@ def clear_main_auth():
 def login_get():
     """Display the login page."""
     referrer = request.referrer or '/'
-    # Only update redirect if referrer is not a login/register page
-    if not any(page in referrer for page in ['/login', '/register']):
+    # Only update redirect if referrer is not an auth-related page
+    excluded_pages = ['/login', '/register', '/logout', '/forgot-password', '/reset-password']
+    if not any(page in referrer for page in excluded_pages):
         session['login_redirect'] = referrer
     
     return render_template('login/login.html')
@@ -66,7 +67,10 @@ def login_post():
             flash('Login successful!', FLASH_SUCCESS)
             
             # Retrieve and clear the redirect from session
+            # Only allow relative URLs to prevent redirecting to external sites
             redirect_url = session.pop('login_redirect', '/')
+            if not redirect_url.startswith('/'):
+                redirect_url = '/'
             return redirect(redirect_url)
         else:
             attempts += 1

--- a/app/controllers/register.py
+++ b/app/controllers/register.py
@@ -19,8 +19,9 @@ register_bp = Blueprint('register', __name__)
 def register_get():
     """Display the registration page."""
     referrer = request.referrer or '/'
-    # Only update redirect if referrer is not a login/register page
-    if not any(page in referrer for page in ['/login', '/register']):
+    # Only update redirect if referrer is not an auth-related page
+    excluded_pages = ['/login', '/register', '/logout', '/forgot-password', '/reset-password']
+    if not any(page in referrer for page in excluded_pages):
         session['login_redirect'] = referrer
     
     return render_template('register/register.html')


### PR DESCRIPTION
Added a login redirect cookie to track the page a user was on prior to logging in.  *see #89* 

We need to use this instead of just using the `request.referrer` in the `return redirect(...)` as registering for an account then logging in would cause us to be redirected back to `/register`, which would in-turn, redirect us to `/` instead of the page a user started on