### PR TITLE
Replace the shell zip cmd with pyminizip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ bleach==6.1.0
 requests==2.31.0
 Werkzeug==3.0.1
 resend==2.0.0
+pyminizip==0.2.6
 
 # Testing
 pytest==7.4.3

--- a/review/routes.py
+++ b/review/routes.py
@@ -21,7 +21,7 @@ import os
 import json
 import re
 import requests
-from subprocess import call
+import pyminizip
 from bson.objectid import ObjectId
 import shutil
 import random
@@ -500,56 +500,27 @@ def create_password_protected_zip(source_path, dest_path_without_ext, filename_i
     Returns:
         Tuple of (success: bool, error_message: str or None)
     """
-    # Move to temp location with desired filename
+    dest_path = dest_path_without_ext + '.zip'
     temp_path = os.path.join(CRACKMESONE_DIR, filename_in_archive)
-    shutil.move(source_path, temp_path)
 
     try:
-        # Find zip command (use full path to avoid PATH issues in web server)
-        zip_cmd = shutil.which("zip") or "/usr/bin/zip"
-
-        # Create password-protected zip
-        ret = call([
-            zip_cmd, "-j", "--password", ARCHIVE_PASSWORD,
-            dest_path_without_ext, "--", temp_path
-        ])
-
-        if ret != 0:
-            # Move file back on failure
-            if os.path.exists(temp_path):
-                try:
-                    shutil.move(temp_path, source_path)
-                except Exception:
-                    pass
-            return False, "Failed to create zip archive"
-
+        shutil.move(source_path, temp_path)
+        pyminizip.compress(temp_path, None, dest_path, ARCHIVE_PASSWORD, 6) #https://linux.die.net/man/1/zip default before was 6, this follows on pyminizip
+        os.remove(temp_path)
         return True, None
 
-    except FileNotFoundError:
-        # zip command not found - move file back
+    except Exception as e:
         if os.path.exists(temp_path):
             try:
                 shutil.move(temp_path, source_path)
             except Exception:
                 pass
-        return False, "zip command not found"
-
-    except Exception as e:
-        # Other errors - move file back
-        if os.path.exists(temp_path):
+        if os.path.exists(dest_path):
             try:
-                shutil.move(temp_path, source_path)
+                os.remove(dest_path)
             except Exception:
                 pass
         return False, f"Error creating zip: {str(e)}"
-
-    finally:
-        # Clean up temp file (only if zip succeeded, file was moved to archive)
-        if os.path.exists(temp_path):
-            try:
-                os.remove(temp_path)
-            except Exception:
-                pass
 
 
 # =============================================================================


### PR DESCRIPTION
Replace the shell zip command with pyminizip to avoid the subprocess schenanigans.

Tested on Windows 11, worked fine via process explorer for me. I also added an edge case to clean up partial zips on failure.

Closes #121 