### PR TITLE
Update CTF announcement - competition is now live

### DIFF
--- a/templates/index/index.html
+++ b/templates/index/index.html
@@ -10,7 +10,7 @@
 
     <div class="toast" style="margin: 20px 0;">
         <p><strong>🏆 Crackmes.one CTF Competition</strong></p>
-        <p>Join our upcoming Capture The Flag competition starting <strong>February 14th, 2026</strong> and test your reverse engineering skills against other experts! Visit <a href="https://crackmesone.ctfd.io/" target="_blank" style="color: #9acc14; font-weight: bold;">crackmesone.ctfd.io</a> for more information.</p>
+        <p>The CTF has started! Running until <strong>February 21st, 2026</strong>. Test your reverse engineering skills against other experts! Visit <a href="https://crackmesone.ctfd.io/" target="_blank" style="color: #9acc14; font-weight: bold;">crackmesone.ctfd.io</a> to participate.</p>
     </div>
 
     <div class="columns">


### PR DESCRIPTION
## Summary
- Updated the front page CTF banner to indicate the competition has started
- Changed end date to February 21st, 2026
- Updated call-to-action from "Join our upcoming" to "The CTF has started!"

## Test plan
- [ ] Verify the front page displays the updated CTF announcement correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)