### PR TITLE
Add comprehensive test and CI coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,47 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  unit-and-route-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: python -m pip install --requirement requirements.txt
+      - name: Check Python syntax
+        run: python -m compileall -q app review tests
+      - name: Run fast tests
+        run: pytest --cov=app --cov=review --cov-branch --cov-report=term-missing --cov-fail-under=75
+
+  mongodb-integration-tests:
+    runs-on: ubuntu-latest
+    services:
+      mongodb:
+        image: mongo:7
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --quiet --eval 'db.runCommand({ ping: 1 })'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      TEST_MONGODB_URL: mongodb://127.0.0.1:27017
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: python -m pip install --requirement requirements.txt
+      - name: Run tests against MongoDB
+        run: pytest

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -17,20 +17,25 @@ from app.services.email import configure as configure_email
 from app.services.view import register_filters
 
 
-def create_app(config_path=None):
-    """Create and configure the Flask application."""
+def create_app(config_path=None, config=None):
+    """Create and configure the Flask application.
+
+    ``config`` allows tests and other callers to supply configuration without
+    creating or modifying the production JSON file.  Production continues to
+    load ``config_path`` when no configuration mapping is supplied.
+    """
     app = Flask(__name__,
                 template_folder='../templates',
                 static_folder='../static')
     app.url_map.strict_slashes = False
 
-    # Load configuration
-    if config_path is None:
-        config_path = os.path.join(os.path.dirname(os.path.dirname(__file__)),
-                                   'config', 'config.json')
+    if config is None:
+        if config_path is None:
+            config_path = os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                                       'config', 'config.json')
 
-    with open(config_path, 'r') as f:
-        config = json.load(f)
+        with open(config_path, 'r') as f:
+            config = json.load(f)
 
     # Configure Flask app
     app.config['SECRET_KEY'] = config['Session']['SecretKey']

--- a/app/services/database.py
+++ b/app/services/database.py
@@ -18,7 +18,9 @@ def init_db(app, config):
         mongo_url = config.get('URL', 'mongodb://127.0.0.1:27017')
         database_name = config.get('Name', 'crackmesone')
 
-        mongo_client = MongoClient(mongo_url)
+        # Tests can inject a disposable compatible client (for example,
+        # mongomock) while production always constructs a real MongoClient.
+        mongo_client = config.get('Client') or MongoClient(mongo_url)
         # Verify connection
         mongo_client.admin.command('ping')
 

--- a/app/services/passhash.py
+++ b/app/services/passhash.py
@@ -23,7 +23,7 @@ def match_string(hashed: str, password: str) -> bool:
     """Check if the password matches the hash."""
     try:
         return bcrypt.checkpw(password.encode('utf-8'), hashed.encode('utf-8'))
-    except (ValueError, TypeError):
+    except (AttributeError, ValueError, TypeError):
         return False
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ resend==2.0.0
 rustyzipper==1.0.6
 
 # Testing
+setuptools<81  # mongomock 4.1.2 imports pkg_resources
 pytest==7.4.3
 pytest-cov==4.1.0
 mongomock==4.1.2

--- a/review/auth.py
+++ b/review/auth.py
@@ -1,0 +1,87 @@
+"""Reviewer authentication, authorization, and CSRF helpers.
+
+This module deliberately owns only reviewer-session security.  Main-site user
+authentication remains separate.
+"""
+
+from functools import wraps
+import hashlib
+import os
+
+from flask import abort, redirect, request, session, url_for
+
+
+REVIEWER_SESSION_KEY = '_reviewer_user'
+REVIEWER_ADMIN_KEY = '_reviewer_is_admin'
+REVIEWER_CSRF_KEY = '_reviewer_csrf_token'
+
+_users = {}
+
+
+def configure(users):
+    """Use the reviewer credential mapping loaded by the reviewer package."""
+    global _users
+    _users = users
+
+
+def hash_string(input_string):
+    """Return a SHA-256 hexadecimal password digest input."""
+    return hashlib.sha256(input_string.encode('utf-8')).hexdigest()
+
+
+def get_current_reviewer():
+    """Return the authenticated reviewer, or ``None`` for a stale session."""
+    username = session.get(REVIEWER_SESSION_KEY)
+    if not username or username not in _users:
+        return None
+    return {
+        'username': username,
+        'is_admin': _users[username].get('is_admin', False),
+    }
+
+
+def clear_reviewer_session():
+    """Remove reviewer authentication without touching main-site auth."""
+    session.pop(REVIEWER_SESSION_KEY, None)
+    session.pop(REVIEWER_ADMIN_KEY, None)
+
+
+def token_required(view):
+    """Require a current reviewer account."""
+    @wraps(view)
+    def decorated(*args, **kwargs):
+        current_user = get_current_reviewer()
+        if not current_user:
+            clear_reviewer_session()
+            return redirect(url_for('reviewer.login'))
+        return view(current_user, *args, **kwargs)
+    return decorated
+
+
+def admin_required(view):
+    """Require a current reviewer account with administrator privileges."""
+    @wraps(view)
+    def decorated(*args, **kwargs):
+        current_user = get_current_reviewer()
+        if not current_user:
+            clear_reviewer_session()
+            return redirect(url_for('reviewer.login'))
+        if not current_user['is_admin']:
+            abort(403)
+        return view(current_user, *args, **kwargs)
+    return decorated
+
+
+def generate_csrf_token():
+    """Generate or retrieve the reviewer-specific CSRF token."""
+    if REVIEWER_CSRF_KEY not in session:
+        session[REVIEWER_CSRF_KEY] = hashlib.sha256(os.urandom(32)).hexdigest()
+    return session[REVIEWER_CSRF_KEY]
+
+
+def validate_csrf_token():
+    """Reject a missing or mismatched reviewer CSRF token."""
+    token = request.form.get('csrf_token')
+    expected = session.get(REVIEWER_CSRF_KEY)
+    if not token or not expected or token != expected:
+        abort(403, description='CSRF token validation failed')

--- a/review/routes.py
+++ b/review/routes.py
@@ -12,11 +12,9 @@ from flask import (
     Blueprint, render_template, request, redirect,
     url_for, abort, send_file, session, jsonify
 )
-from functools import wraps
 from html import escape as html_escape
 import datetime
 from datetime import timezone
-import hashlib
 import json
 import os
 import random
@@ -31,6 +29,19 @@ from rustyzipper import compress_file, EncryptionMethod
 from bson.objectid import ObjectId
 
 from review.logger import log_reviewer_operation
+from review.auth import (
+    REVIEWER_ADMIN_KEY,
+    REVIEWER_CSRF_KEY,
+    REVIEWER_SESSION_KEY,
+    admin_required,
+    clear_reviewer_session,
+    configure as configure_reviewer_auth,
+    generate_csrf_token,
+    get_current_reviewer,
+    hash_string,
+    token_required,
+    validate_csrf_token,
+)
 from app.services.crypto import get_obfuscation_salt
 from app.services.view import is_valid_hexid
 
@@ -55,11 +66,6 @@ WRITEUP_OBFUSCATION_SALT = None
 g_crackmesone_db = None
 users = {}
 USERS_FILE = os.path.join(os.path.dirname(__file__), 'users.json')
-
-# Session keys for reviewer authentication (prefixed to avoid conflicts)
-REVIEWER_SESSION_KEY = '_reviewer_user'
-REVIEWER_ADMIN_KEY = '_reviewer_is_admin'
-REVIEWER_CSRF_KEY = '_reviewer_csrf_token'
 
 # Archive password for approved submissions
 ARCHIVE_PASSWORD = 'crackmes.one'
@@ -104,6 +110,8 @@ def init_reviewer(app):
         with open(USERS_FILE, 'r') as f:
             users.update(json.load(f))
 
+    configure_reviewer_auth(users)
+
 
 def save_users():
     """
@@ -114,110 +122,6 @@ def save_users():
     """
     with open(USERS_FILE, 'w') as f:
         json.dump(users, f, indent=2)
-
-
-# =============================================================================
-# Authentication Helpers
-# =============================================================================
-
-def hash_string(input_string):
-    """
-    Hash a string using SHA256.
-
-    Args:
-        input_string: Plain text string to hash
-
-    Returns:
-        Hexadecimal string representation of the SHA256 hash
-    """
-    return hashlib.sha256(input_string.encode('utf-8')).hexdigest()
-
-
-def get_current_reviewer():
-    """
-    Get the current authenticated reviewer from session.
-
-    Returns:
-        Dict with 'username' and 'is_admin' keys if authenticated,
-        None if not authenticated or user no longer exists.
-    """
-    username = session.get(REVIEWER_SESSION_KEY)
-    if not username or username not in users:
-        return None
-    return {
-        'username': username,
-        'is_admin': users[username].get('is_admin', False)
-    }
-
-
-def clear_reviewer_session():
-    """Remove reviewer authentication from session."""
-    session.pop(REVIEWER_SESSION_KEY, None)
-    session.pop(REVIEWER_ADMIN_KEY, None)
-
-
-def token_required(f):
-    """
-    Decorator requiring reviewer authentication.
-
-    Redirects to login page if not authenticated. Passes current_user
-    dict as first argument to the decorated function.
-    """
-    @wraps(f)
-    def decorated(*args, **kwargs):
-        current_user = get_current_reviewer()
-        if not current_user:
-            clear_reviewer_session()
-            return redirect(url_for('reviewer.login'))
-        return f(current_user, *args, **kwargs)
-    return decorated
-
-
-def admin_required(f):
-    """
-    Decorator requiring admin authentication.
-
-    Redirects to login if not authenticated, returns 403 if authenticated
-    but not an admin. Passes current_user dict as first argument.
-    """
-    @wraps(f)
-    def decorated(*args, **kwargs):
-        current_user = get_current_reviewer()
-        if not current_user:
-            clear_reviewer_session()
-            return redirect(url_for('reviewer.login'))
-        if not current_user['is_admin']:
-            abort(403)
-        return f(current_user, *args, **kwargs)
-    return decorated
-
-
-# =============================================================================
-# CSRF Protection
-# =============================================================================
-
-def generate_csrf_token():
-    """
-    Generate or retrieve CSRF token for the current session.
-
-    Returns:
-        32-byte hex string CSRF token
-    """
-    if REVIEWER_CSRF_KEY not in session:
-        session[REVIEWER_CSRF_KEY] = hashlib.sha256(os.urandom(32)).hexdigest()
-    return session[REVIEWER_CSRF_KEY]
-
-
-def validate_csrf_token():
-    """
-    Validate CSRF token from form submission.
-
-    Aborts with 403 if token is missing or invalid.
-    """
-    token = request.form.get('csrf_token')
-    expected = session.get(REVIEWER_CSRF_KEY)
-    if not token or not expected or token != expected:
-        abort(403, description="CSRF token validation failed")
 
 
 @reviewer_bp.context_processor

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,91 +1,182 @@
-"""
-Pytest configuration and fixtures for crackmes.one tests.
-"""
-import pytest
-from unittest.mock import MagicMock, patch
+"""Shared, isolated fixtures for application and model tests."""
+
+import os
+
 import mongomock
-from flask import Flask
+import pytest
+from pymongo import MongoClient
+
+from app.services.passhash import hash_string
+
+
+def _test_config(mongo_client, database_name):
+    return {
+        'Database': {
+            'URL': os.getenv('TEST_MONGODB_URL', 'mongodb://127.0.0.1:27017'),
+            'Name': database_name,
+            'Client': mongo_client,
+        },
+        'Recaptcha': {'Enabled': False, 'SiteKey': '', 'Secret': ''},
+        'Session': {'SecretKey': 'test-secret-key', 'CookieName': 'test-session'},
+        'RateLimiter': {'Enabled': False, 'StorageUri': 'memory://'},
+        'Discord': {'Enabled': False},
+        'Email': {'Enabled': False},
+        'Reviewer': {'Enabled': True, 'PasswordSalt': 'test-reviewer-salt'},
+        'Site': {'BaseURL': 'http://localhost'},
+        'Writeup': {'ObfuscationSalt': 'test-obfuscation-salt'},
+    }
+
+
+@pytest.fixture(scope='session')
+def mongo_client():
+    """Use mongomock locally or a disposable real MongoDB when configured."""
+    mongo_url = os.getenv('TEST_MONGODB_URL')
+    client = MongoClient(mongo_url) if mongo_url else mongomock.MongoClient()
+    if mongo_url:
+        client.admin.command('ping')
+    yield client
+    client.drop_database('test_crackmesone')
+    client.close()
+
+
+@pytest.fixture(scope='session')
+def app(mongo_client):
+    from app import create_app
+
+    application = create_app(config=_test_config(mongo_client, 'test_crackmesone'))
+    application.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
+    yield application
 
 
 @pytest.fixture
-def app():
-    """Create a test Flask application."""
-    from app import create_app
-
-    # Mock the config to use test settings
-    test_config = {
-        'Database': {
-            'MongoDB': {
-                'URL': 'mongodb://localhost:27017',
-                'Database': 'test_crackmesone'
-            }
-        },
-        'Recaptcha': {
-            'Enabled': False,
-            'SiteKey': 'test-site-key',
-            'Secret': 'test-secret'
-        },
-        'Session': {
-            'SecretKey': 'test-secret-key'
-        },
-        'Server': {
-            'HTTPPort': 5000
-        }
-    }
-
-    with patch('app.services.database.load_config', return_value=test_config):
-        with patch('app.services.database.MongoClient') as mock_client:
-            mock_client.return_value = mongomock.MongoClient()
-            app = create_app()
-            app.config['TESTING'] = True
-            app.config['WTF_CSRF_ENABLED'] = False
-            yield app
+def db(app):
+    database = app.config['MONGO_DB']
+    for collection_name in database.list_collection_names():
+        database.drop_collection(collection_name)
+    yield database
+    for collection_name in database.list_collection_names():
+        database.drop_collection(collection_name)
 
 
 @pytest.fixture
 def client(app):
-    """Create a test client."""
     return app.test_client()
+
+
+@pytest.fixture(autouse=True)
+def reset_external_service_config(app):
+    """Prevent tests that change process-global service config leaking state."""
+    from app.services.recaptcha import init_recaptcha
+    from review import auth, routes
+
+    init_recaptcha(app, app.config['APP_CONFIG']['Recaptcha'])
+    auth.configure(routes.users)
 
 
 @pytest.fixture
 def runner(app):
-    """Create a test CLI runner."""
     return app.test_cli_runner()
 
 
 @pytest.fixture
-def mock_db():
-    """Create a mock MongoDB database."""
-    return mongomock.MongoClient().test_crackmesone
-
-
-@pytest.fixture
-def sample_user():
-    """Sample user data for testing."""
-    return {
-        'name': 'testuser',
-        'email': 'test@example.com',
-        'password': 'password123',
-        'level': 0,
-        'nbcrackmes': 0,
-        'nbsolutions': 0,
-        'nbcomments': 0
+def alice(db):
+    user = {
+        'name': 'alice',
+        'email': 'alice@example.test',
+        'password': hash_string('alice-password'),
+        'visible': True,
+        'deleted': False,
+        'unread_notifications': 0,
     }
+    db.user.insert_one(user)
+    return user
 
 
 @pytest.fixture
-def sample_crackme():
-    """Sample crackme data for testing."""
-    return {
+def bob(db):
+    user = {
+        'name': 'bob',
+        'email': 'bob@example.test',
+        'password': hash_string('bob-password'),
+        'visible': True,
+        'deleted': False,
+        'unread_notifications': 0,
+    }
+    db.user.insert_one(user)
+    return user
+
+
+def _authenticate(client, user):
+    with client.session_transaction() as session:
+        session['name'] = user['name']
+        session['email'] = user['email']
+    return client
+
+
+@pytest.fixture
+def alice_client(app, alice):
+    return _authenticate(app.test_client(), alice)
+
+
+@pytest.fixture
+def bob_client(app, bob):
+    return _authenticate(app.test_client(), bob)
+
+
+@pytest.fixture
+def reviewer_account():
+    from review import routes
+
+    routes.users['reviewer'] = {
+        'password_hash': routes.hash_string(
+            'reviewer-password' + 'test-reviewer-salt'
+        ),
+        'is_admin': False,
+    }
+    yield routes.users['reviewer']
+    routes.users.pop('reviewer', None)
+
+
+@pytest.fixture
+def reviewer_client(app, reviewer_account):
+    from review.routes import (
+        REVIEWER_ADMIN_KEY,
+        REVIEWER_CSRF_KEY,
+        REVIEWER_SESSION_KEY,
+    )
+
+    client = app.test_client()
+    with client.session_transaction() as session:
+        session[REVIEWER_SESSION_KEY] = 'reviewer'
+        session[REVIEWER_ADMIN_KEY] = False
+        session[REVIEWER_CSRF_KEY] = 'test-csrf-token'
+    return client
+
+
+@pytest.fixture
+def sample_crackme(db, alice):
+    from bson import ObjectId
+    from datetime import datetime, timezone
+
+    object_id = ObjectId()
+    crackme = {
+        '_id': object_id,
+        'hexid': str(object_id),
         'name': 'Test Crackme',
-        'author': 'testuser',
-        'info': 'A test crackme for unit testing',
+        'author': alice['name'],
+        'info': 'A test crackme',
         'lang': 'C/C++',
         'arch': 'x86-64',
         'platform': 'Linux',
         'difficulty': 3.0,
         'quality': 4.0,
+        'visible': True,
+        'deleted': False,
         'nbsolutions': 0,
-        'nbcomments': 0
+        'nbcomments': 0,
+        'nbdownloads': 0,
+        'size': 100,
+        'created_at': datetime.now(timezone.utc),
     }
+    db.crackme.insert_one(crackme)
+    return crackme

--- a/tests/test_comments_and_crackmes.py
+++ b/tests/test_comments_and_crackmes.py
@@ -1,0 +1,118 @@
+"""Integration tests for comments and crackme ownership/upload workflows."""
+
+from io import BytesIO
+
+
+def test_comment_creation_updates_count_and_notifies_owner(
+        bob_client, db, sample_crackme, bob):
+    response = bob_client.post(
+        f"/comment/{sample_crackme['hexid']}",
+        data={'comment': 'Useful challenge, thanks!'},
+    )
+
+    assert response.status_code == 302
+    comment = db.comment.find_one({'author': 'bob'})
+    assert comment['info'] == 'Useful challenge, thanks!'
+    assert comment['spoiler'] is False
+    assert db.crackme.find_one({'_id': sample_crackme['_id']})['nbcomments'] == 1
+    assert db.notifications.count_documents({'user': 'alice'}) == 1
+
+
+def test_comment_mentions_only_existing_thread_participants(
+        alice_client, bob_client, db, sample_crackme, bob):
+    alice_client.post(
+        f"/comment/{sample_crackme['hexid']}", data={'comment': 'Initial note'}
+    )
+    db.notifications.delete_many({})
+
+    bob_client.post(
+        f"/comment/{sample_crackme['hexid']}",
+        data={'comment': '@alice and @outsider please review'},
+    )
+
+    assert db.notifications.count_documents({'user': 'alice'}) == 1
+    assert db.notifications.count_documents({'user': 'outsider'}) == 0
+
+
+def test_crackme_author_can_toggle_any_comment_spoiler(
+        alice_client, db, sample_crackme, bob):
+    from app.models.comment import comment_create
+
+    comment = comment_create('Potential spoiler', 'bob', sample_crackme['hexid'])
+    path = f"/comment/{comment['_id']}/spoiler"
+
+    assert alice_client.post(path).status_code == 302
+    assert db.comment.find_one({'_id': comment['_id']})['spoiler'] is True
+    assert alice_client.post(path).status_code == 302
+    assert db.comment.find_one({'_id': comment['_id']})['spoiler'] is False
+
+
+def test_comment_author_cannot_remove_own_spoiler(
+        bob_client, db, sample_crackme, bob):
+    from app.models.comment import comment_create
+
+    comment = comment_create(
+        'My spoiler', 'bob', sample_crackme['hexid'], spoiler=True
+    )
+    response = bob_client.post(f"/comment/{comment['_id']}/spoiler")
+
+    assert response.status_code == 302
+    assert db.comment.find_one({'_id': comment['_id']})['spoiler'] is True
+
+
+def test_crackme_upload_creates_pending_record_file_and_ratings(
+        alice_client, db, alice, tmp_path, monkeypatch):
+    from app.controllers import crackme as crackme_controller
+
+    monkeypatch.setattr(crackme_controller, 'UPLOAD_FOLDER', str(tmp_path))
+    response = alice_client.post('/upload/crackme', data={
+        'name': 'Uploaded Challenge',
+        'info': 'Analyze this small challenge.',
+        'lang': 'C/C++',
+        'difficulty': '3',
+        'platform': 'Linux',
+        'arch': 'x86-64',
+        'file': (BytesIO(b'not-an-archive-binary'), '../../challenge.bin'),
+    }, content_type='multipart/form-data')
+
+    assert response.status_code == 200
+    crackme = db.crackme.find_one({'name': 'Uploaded Challenge'})
+    assert crackme['visible'] is False
+    assert crackme['original_filename'] == 'challenge.bin'
+    assert (tmp_path / crackme['hexid']).read_bytes() == b'not-an-archive-binary'
+    assert db.rating_difficulty.find_one({'crackmehexid': crackme['hexid']})['rating'] == 3
+    assert db.rating_quality.find_one({'crackmehexid': crackme['hexid']})['rating'] == 4
+
+
+def test_crackme_upload_requires_all_metadata_and_file(alice_client, db, alice):
+    missing_metadata = alice_client.post('/upload/crackme', data={'name': 'Incomplete'})
+    missing_file = alice_client.post('/upload/crackme', data={
+        'name': 'No File', 'info': 'Info', 'lang': 'C/C++', 'difficulty': '3',
+        'platform': 'Linux', 'arch': 'x86-64',
+    })
+
+    assert missing_metadata.status_code == 200
+    assert b'Field missing: info' in missing_metadata.data
+    assert missing_file.status_code == 200
+    assert b'Field missing: file' in missing_file.data
+    assert db.crackme.count_documents({}) == 0
+
+
+def test_owner_can_edit_crackme_but_other_user_cannot(
+        alice_client, bob_client, db, sample_crackme, bob):
+    path = f"/crackme/{sample_crackme['hexid']}/edit"
+
+    denied = bob_client.post(path, data={
+        'info': 'Unauthorized', 'lang': 'Python', 'arch': 'ARM',
+        'platform': 'Windows',
+    })
+    allowed = alice_client.post(path, data={
+        'info': 'Updated information', 'lang': 'Rust', 'arch': 'ARM',
+        'platform': 'Linux',
+    })
+
+    assert denied.status_code == 302
+    assert allowed.status_code == 302
+    updated = db.crackme.find_one({'_id': sample_crackme['_id']})
+    assert updated['info'] == 'Updated information'
+    assert updated['lang'] == 'Rust'

--- a/tests/test_controller_edge_cases.py
+++ b/tests/test_controller_edge_cases.py
@@ -1,0 +1,233 @@
+"""High-value validation and failure branches across public controllers."""
+
+from io import BytesIO
+from unittest.mock import patch
+
+import pytest
+
+
+def test_login_by_email_and_safe_referrer(client, alice):
+    page = client.get('/login', headers={'Referer': 'http://localhost/crackme/abc'})
+    assert page.status_code == 200
+    response = client.post('/login', data={
+        'name': 'alice@example.test', 'password': 'alice-password',
+    })
+    assert response.status_code == 302
+    assert response.location == '/crackme/abc'
+
+
+def test_login_does_not_redirect_to_external_referrer(client, alice):
+    client.get('/login', headers={'Referer': 'https://evil.example/phish'})
+    response = client.post('/login', data={
+        'name': 'alice', 'password': 'alice-password',
+    })
+    assert response.location == '/'
+
+
+def test_login_missing_and_invalid_name(client):
+    missing = client.post('/login', data={'name': '', 'password': ''})
+    invalid = client.post('/login', data={'name': '<script>', 'password': 'x'})
+    assert b'Field missing: name' in missing.data
+    assert b'Non authorized chars' in invalid.data
+
+
+def test_login_database_failure_is_generic(client):
+    with patch('app.controllers.login.user_by_mail', side_effect=RuntimeError):
+        response = client.post('/login', data={'name': 'alice', 'password': 'x'})
+    assert response.status_code == 200
+    assert b'error' in response.data.lower()
+
+
+def test_registration_rejects_duplicate_email_and_username(client, alice):
+    duplicate_email = client.post('/register', data={
+        'name': 'different', 'email': 'alice@example.test', 'password': 'password123',
+    })
+    duplicate_name = client.post('/register', data={
+        'name': 'alice', 'email': 'different@example.test', 'password': 'password123',
+    })
+    assert b'Account already exists' in duplicate_email.data
+    assert b'Account already exists' in duplicate_name.data
+
+
+def test_registration_cross_field_conflicts(client, db):
+    db.user.insert_one({
+        'name': 'existing@example.test', 'email': 'existing-email@example.test',
+        'password': 'hash',
+    })
+    username_is_email = client.post('/register', data={
+        'name': 'existing-email@example.test', 'email': 'new@example.test',
+        'password': 'password123',
+    })
+    email_is_username = client.post('/register', data={
+        'name': 'new-user', 'email': 'existing@example.test',
+        'password': 'password123',
+    })
+    assert b'username is not available' in username_is_email.data
+    assert b'email is not available' in email_is_username.data
+
+
+def test_registration_rejects_invalid_chars_and_recaptcha(client):
+    invalid = client.post('/register', data={
+        'name': 'bad name', 'email': 'valid@example.test', 'password': 'password123',
+    })
+    with patch('app.controllers.register.verify_recaptcha', return_value=False):
+        captcha = client.post('/register', data={
+            'name': 'valid', 'email': 'valid@example.test', 'password': 'password123',
+        })
+    assert b'Non allowed chars' in invalid.data
+    assert b'reCAPTCHA invalid' in captcha.data
+
+
+def test_registration_hash_and_create_failures(client):
+    data = {'name': 'newuser', 'email': 'new@example.test', 'password': 'password123'}
+    with patch('app.controllers.register.hash_string', side_effect=RuntimeError):
+        hashing = client.post('/register', data=data)
+    with patch('app.controllers.register.user_create', side_effect=RuntimeError):
+        creation = client.post('/register', data=data)
+    assert hashing.status_code == 302
+    assert creation.status_code == 200
+
+
+@pytest.mark.parametrize(('difficulty', 'message'), [
+    ('0', b'Wrong difficulty'), ('7', b'Wrong difficulty'), ('bad', b'Wrong difficulty'),
+])
+def test_crackme_upload_rejects_invalid_difficulty(
+        alice_client, alice, difficulty, message):
+    response = alice_client.post('/upload/crackme', data={
+        'name': 'Challenge', 'info': 'Info', 'lang': 'C', 'difficulty': difficulty,
+        'platform': 'Linux', 'arch': 'x86',
+        'file': (BytesIO(b'data'), 'challenge.bin'),
+    }, content_type='multipart/form-data')
+    assert message in response.data
+
+
+@pytest.mark.parametrize(('validator', 'message'), [
+    ('is_unsupported_archive', b'RAR and tar'),
+    ('is_archive_password_protected', b'Password-protected'),
+    ('is_single_file_archive', b'only one file'),
+])
+def test_crackme_upload_archive_rejections(
+        alice_client, alice, validator, message):
+    with patch(f'app.controllers.crackme.{validator}', return_value=True):
+        response = alice_client.post('/upload/crackme', data={
+            'name': 'Challenge', 'info': 'Info', 'lang': 'C', 'difficulty': '3',
+            'platform': 'Linux', 'arch': 'x86',
+            'file': (BytesIO(b'data'), 'challenge.bin'),
+        }, content_type='multipart/form-data')
+    assert message in response.data
+
+
+def test_crackme_upload_rejects_oversized_file(alice_client, alice):
+    with patch('app.controllers.crackme.MAX_FILE_SIZE', 2):
+        response = alice_client.post('/upload/crackme', data={
+            'name': 'Challenge', 'info': 'Info', 'lang': 'C', 'difficulty': '3',
+            'platform': 'Linux', 'arch': 'x86',
+            'file': (BytesIO(b'too large'), 'challenge.bin'),
+        }, content_type='multipart/form-data')
+    assert b'This file is too large' in response.data
+
+
+def test_crackme_view_download_and_lasts(client, db, sample_crackme):
+    page = client.get(f"/crackme/{sample_crackme['hexid']}")
+    download = client.get(f"/download/crackme/{sample_crackme['hexid']}")
+    lasts = client.get('/lasts')
+    assert page.status_code == 200
+    assert b'Test Crackme' in page.data
+    assert download.location == f"/static/crackme/{sample_crackme['hexid']}.zip"
+    assert db.crackme.find_one({'_id': sample_crackme['_id']})['nbdownloads'] == 1
+    assert lasts.location == '/lasts/1'
+
+
+def test_comment_validation_sanitization_and_recaptcha(
+        bob_client, db, sample_crackme, bob):
+    missing = bob_client.post(f"/comment/{sample_crackme['hexid']}", data={})
+    with patch('app.controllers.comment.verify_recaptcha', return_value=False):
+        captcha = bob_client.post(
+            f"/comment/{sample_crackme['hexid']}", data={'comment': 'hello'}
+        )
+    sanitized = bob_client.post(
+        f"/comment/{sample_crackme['hexid']}",
+        data={'comment': '<script>alert(1)</script><b>safe</b>'},
+    )
+    assert missing.status_code == captcha.status_code == sanitized.status_code == 302
+    stored = db.comment.find_one({})['info']
+    assert '<script>' not in stored
+    assert '<b>safe</b>' in stored
+
+
+def test_spoiler_token_is_single_use(bob_client, client, db, sample_crackme, bob):
+    from app.controllers import comment as controller
+
+    bob_client.post(f"/comment/{sample_crackme['hexid']}", data={'comment': 'spoiler'})
+    comment = db.comment.find_one({'author': 'bob'})
+    token = controller._spoiler_tokens[str(comment['_id'])]
+    path = f"/comment/{comment['_id']}/spoiler-token/{token}"
+    first = client.get(path)
+    second = client.get(path)
+    assert b'success' in first.data.lower()
+    assert b'Invalid token' in second.data
+    assert db.comment.find_one({'_id': comment['_id']})['spoiler'] is True
+
+
+def test_password_reset_quota_and_unconfigured_email(client, db):
+    with patch('app.controllers.password_reset.quota_exceeded', return_value=True):
+        get_response = client.get('/forgot-password')
+        post_response = client.post('/forgot-password', data={'email': 'a@example.test'})
+    with patch('app.controllers.password_reset.email_is_configured', return_value=False):
+        unavailable = client.post('/forgot-password', data={'email': 'a@example.test'})
+    assert get_response.status_code == post_response.status_code == unavailable.status_code == 200
+    assert b'unavailable' in unavailable.data.lower()
+
+
+def test_password_reset_per_address_quota_hides_limit(client):
+    with patch('app.controllers.password_reset.email_is_configured', return_value=True), \
+         patch('app.controllers.password_reset.email_quota_exceeded', return_value=True), \
+         patch('app.controllers.password_reset.user_by_mail') as lookup:
+        response = client.post('/forgot-password', data={'email': 'a@example.test'})
+    assert response.status_code == 200
+    lookup.assert_not_called()
+
+
+@pytest.mark.parametrize('payload', [
+    {'new_password': '', 'new_password_verify': ''},
+    {'new_password': 'short', 'new_password_verify': 'short'},
+])
+def test_password_reset_rejects_empty_and_short_passwords(client, alice, payload):
+    from app.models.password_reset import create_reset_token
+    token = create_reset_token('alice@example.test')
+    response = client.post(f'/reset-password/{token}', data=payload)
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(('validator', 'message'), [
+    ('is_unsupported_archive', b'RAR and tar'),
+    ('is_archive_password_protected', b'Password-protected'),
+    ('is_single_file_archive', b'only one file'),
+    ('is_pe_file', b'Executable files'),
+])
+def test_solution_attachment_rejections(
+        alice_client, db, sample_crackme, validator, message):
+    with patch(f'app.controllers.solution.{validator}', return_value=True):
+        response = alice_client.post(
+            f"/upload/solution/{sample_crackme['hexid']}",
+            data={'info': 'Summary', 'file': (BytesIO(b'data'), 'file.bin')},
+            content_type='multipart/form-data',
+        )
+    assert response.status_code == 302
+    with alice_client.session_transaction() as session:
+        assert message in session['_flashes'][-1][1].encode()
+    assert db.solution.count_documents({}) == 0
+
+
+def test_solution_rejects_long_summary_and_recaptcha(alice_client, db, sample_crackme):
+    long_info = alice_client.post(
+        f"/upload/solution/{sample_crackme['hexid']}",
+        data={'info': 'x' * 201, 'content': 'a' * 200},
+    )
+    with patch('app.controllers.solution.verify_recaptcha', return_value=False):
+        captcha = alice_client.post(
+            f"/upload/solution/{sample_crackme['hexid']}",
+            data={'info': 'Summary', 'content': 'a' * 200},
+        )
+    assert long_info.status_code == captcha.status_code == 302
+    assert db.solution.count_documents({}) == 0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,144 +1,69 @@
-"""
-Unit tests for database models.
-"""
+"""Integration tests for models using the configured disposable database."""
+
 import pytest
-from unittest.mock import MagicMock, patch
-from bson import ObjectId
-from datetime import datetime
+
+from app.models.errors import ErrNoResult
+from app.models.user import user_by_mail, user_by_name
 
 
-class TestUserModel:
-    """Tests for User model functions."""
-
-    def test_user_by_name_found(self, mock_db, sample_user):
-        """Test finding a user by name."""
-        mock_db.users.insert_one(sample_user)
-
-        with patch('app.models.user.get_db', return_value=mock_db):
-            from app.models.user import user_by_name
-            result = user_by_name('testuser')
-            assert result is not None
-            assert result['name'] == 'testuser'
-
-    def test_user_by_name_not_found(self, mock_db):
-        """Test finding a non-existent user by name."""
-        with patch('app.models.user.get_db', return_value=mock_db):
-            from app.models.user import user_by_name
-            result = user_by_name('nonexistent')
-            assert result is None
-
-    def test_user_by_email_found(self, mock_db, sample_user):
-        """Test finding a user by email."""
-        mock_db.users.insert_one(sample_user)
-
-        with patch('app.models.user.get_db', return_value=mock_db):
-            from app.models.user import user_by_email
-            result = user_by_email('test@example.com')
-            assert result is not None
-            assert result['email'] == 'test@example.com'
-
-    def test_user_by_email_not_found(self, mock_db):
-        """Test finding a non-existent user by email."""
-        with patch('app.models.user.get_db', return_value=mock_db):
-            from app.models.user import user_by_email
-            result = user_by_email('nonexistent@example.com')
-            assert result is None
+def test_user_lookup_is_case_insensitive(app, alice):
+    assert user_by_name('ALICE')['email'] == 'alice@example.test'
+    assert user_by_mail('ALICE@EXAMPLE.TEST')['name'] == 'alice'
 
 
-class TestCrackmeModel:
-    """Tests for Crackme model functions."""
-
-    def test_crackme_by_hexid_found(self, mock_db, sample_crackme):
-        """Test finding a crackme by hex ID."""
-        result = mock_db.crackmes.insert_one(sample_crackme)
-        hexid = str(result.inserted_id)
-
-        with patch('app.models.crackme.get_db', return_value=mock_db):
-            from app.models.crackme import crackme_by_hexid
-            crackme = crackme_by_hexid(hexid)
-            assert crackme is not None
-            assert crackme['name'] == 'Test Crackme'
-
-    def test_crackme_by_hexid_not_found(self, mock_db):
-        """Test finding a non-existent crackme."""
-        fake_id = str(ObjectId())
-
-        with patch('app.models.crackme.get_db', return_value=mock_db):
-            from app.models.crackme import crackme_by_hexid
-            result = crackme_by_hexid(fake_id)
-            assert result is None
-
-    def test_crackme_by_hexid_invalid_id(self, mock_db):
-        """Test finding a crackme with invalid hex ID."""
-        with patch('app.models.crackme.get_db', return_value=mock_db):
-            from app.models.crackme import crackme_by_hexid
-            result = crackme_by_hexid('invalid-id')
-            assert result is None
-
-    def test_get_last_crackmes(self, mock_db, sample_crackme):
-        """Test getting the last crackmes."""
-        # Insert multiple crackmes
-        for i in range(5):
-            crackme = sample_crackme.copy()
-            crackme['name'] = f'Crackme {i}'
-            crackme['visible'] = True
-            mock_db.crackmes.insert_one(crackme)
-
-        with patch('app.models.crackme.get_db', return_value=mock_db):
-            from app.models.crackme import get_last_crackmes
-            crackmes = get_last_crackmes(page=1, per_page=3)
-            assert len(crackmes) == 3
+def test_missing_user_raises(app):
+    with pytest.raises(ErrNoResult):
+        user_by_name('missing')
 
 
-class TestCommentModel:
-    """Tests for Comment model functions."""
+def test_crackme_lookup_and_counts(app, sample_crackme):
+    from app.models.crackme import (
+        count_crackmes,
+        count_crackmes_by_user,
+        crackme_by_hexid,
+    )
 
-    def test_get_comments_for_crackme(self, mock_db):
-        """Test getting comments for a crackme."""
-        crackme_id = ObjectId()
-        comments = [
-            {
-                'crackmeid': crackme_id,
-                'author': 'user1',
-                'content': 'Great crackme!',
-                'created_at': datetime.utcnow()
-            },
-            {
-                'crackmeid': crackme_id,
-                'author': 'user2',
-                'content': 'Very challenging!',
-                'created_at': datetime.utcnow()
-            }
-        ]
-        for comment in comments:
-            mock_db.comments.insert_one(comment)
-
-        with patch('app.models.comment.get_db', return_value=mock_db):
-            from app.models.comment import get_comments_for_crackme
-            result = get_comments_for_crackme(str(crackme_id))
-            assert len(result) == 2
+    found = crackme_by_hexid(sample_crackme['hexid'])
+    assert found['name'] == 'Test Crackme'
+    assert count_crackmes() == 1
+    assert count_crackmes_by_user('alice') == 1
 
 
-class TestSolutionModel:
-    """Tests for Solution model functions."""
+def test_missing_crackme_raises(app):
+    from bson import ObjectId
+    from app.models.crackme import crackme_by_hexid
 
-    def test_get_solutions_for_crackme(self, mock_db):
-        """Test getting solutions for a crackme."""
-        crackme_id = ObjectId()
-        solutions = [
-            {
-                'crackmeid': crackme_id,
-                'author': 'solver1',
-                'info': 'Used static analysis',
-                'visible': True,
-                'created_at': datetime.utcnow()
-            }
-        ]
-        for solution in solutions:
-            mock_db.solutions.insert_one(solution)
+    with pytest.raises(ErrNoResult):
+        crackme_by_hexid(str(ObjectId()))
 
-        with patch('app.models.solution.get_db', return_value=mock_db):
-            from app.models.solution import get_solutions_for_crackme
-            result = get_solutions_for_crackme(str(crackme_id))
-            assert len(result) == 1
-            assert result[0]['author'] == 'solver1'
+
+def test_comments_are_ordered_and_hidden_comments_excluded(app, db, sample_crackme):
+    from datetime import datetime, timedelta, timezone
+    from app.models.comment import comments_by_crackme
+
+    now = datetime.now(timezone.utc)
+    db.comment.insert_many([
+        {'author': 'bob', 'crackmehexid': sample_crackme['hexid'],
+         'info': 'second', 'visible': True, 'created_at': now},
+        {'author': 'alice', 'crackmehexid': sample_crackme['hexid'],
+         'info': 'first', 'visible': True, 'created_at': now - timedelta(minutes=1)},
+        {'author': 'alice', 'crackmehexid': sample_crackme['hexid'],
+         'info': 'hidden', 'visible': False, 'created_at': now},
+    ])
+
+    assert [item['info'] for item in comments_by_crackme(sample_crackme['hexid'])] == [
+        'first', 'second'
+    ]
+
+
+def test_solution_exists_for_only_the_submitting_user(app, db, sample_crackme):
+    from app.models.solution import solution_exists
+
+    db.solution.insert_one({
+        'author': 'alice',
+        'crackmeid': sample_crackme['_id'],
+        'visible': True,
+    })
+
+    assert solution_exists('alice', sample_crackme['_id']) is True
+    assert solution_exists('bob', sample_crackme['_id']) is False

--- a/tests/test_models_extended.py
+++ b/tests/test_models_extended.py
@@ -1,0 +1,164 @@
+"""Broader model coverage for queries, counters, cleanup, and state transitions."""
+
+from datetime import datetime, timedelta, timezone
+
+from bson import ObjectId
+
+
+def test_crackme_query_counter_and_mutation_helpers(app, db, sample_crackme):
+    from app.models import crackme
+
+    crackme.crackme_increment_comments(sample_crackme['hexid'])
+    crackme.crackme_decrement_comments(sample_crackme['hexid'])
+    crackme.crackme_increment_downloads(sample_crackme['hexid'])
+    crackme.crackme_set_float(sample_crackme['hexid'], 'quality', 5)
+    assert crackme.count_crackmes_by_user('alice') == 1
+    assert len(crackme.get_all_crackmes()) == 1
+    assert len(crackme.crackmes_by_user('alice')) == 1
+    assert crackme.crackme_by_user_and_name('alice', 'Test Crackme')['hexid'] == sample_crackme['hexid']
+    stored = db.crackme.find_one({'_id': sample_crackme['_id']})
+    assert stored['nbcomments'] == 0
+    assert stored['nbdownloads'] == 1
+    assert stored['quality'] == 5.0
+
+
+def test_crackme_search_pagination_sort_and_random(app, db, sample_crackme):
+    from app.models.crackme import random_crackmes, search_crackme
+
+    for index in range(3):
+        item = dict(sample_crackme)
+        item['_id'] = ObjectId()
+        item['hexid'] = str(item['_id'])
+        item['name'] = f'Extra {index}'
+        item['size'] = 1000 + index
+        db.crackme.insert_one(item)
+    results, has_more = search_crackme(page=1, per_page=2, sort_by='size', sort_order='asc')
+    assert len(results) == 2
+    assert has_more is True
+    assert results[0]['size'] <= results[1]['size']
+    assert len(random_crackmes(2)) == 2
+
+
+def test_crackme_prepare_insert_update_and_delete(app, db):
+    from app.models.crackme import (
+        crackme_create_prepare, crackme_delete_by_hexid, crackme_insert,
+        crackme_update, crackme_by_hexid_any,
+    )
+
+    item = crackme_create_prepare(
+        'Prepared', 'Info', 'alice', 'C', 'x86', 'Linux', 20, 'file.bin'
+    )
+    crackme_insert(item)
+    assert crackme_by_hexid_any(item['hexid'])['visible'] is False
+    assert crackme_update(item['hexid'], {'info': 'Changed'}) == {
+        'info': {'old': 'Info', 'new': 'Changed'}
+    }
+    assert crackme_update(item['hexid'], {'info': 'Changed'}) == {}
+    crackme_delete_by_hexid(item['hexid'])
+    assert db.crackme.count_documents({}) == 0
+
+
+def test_comment_query_participant_and_spoiler_helpers(app, db, sample_crackme):
+    from app.models.comment import (
+        comment_by_id, comment_create, comment_set_spoiler,
+        comments_by_user, count_comments_by_crackme, count_comments_by_user,
+        get_thread_participants,
+    )
+
+    first = comment_create('First', 'alice', sample_crackme['hexid'])
+    comment_create('Second', 'bob', sample_crackme['hexid'])
+    assert count_comments_by_user('alice') == 1
+    assert count_comments_by_crackme(sample_crackme['hexid']) == 2
+    assert len(comments_by_user('alice')) == 1
+    assert get_thread_participants(sample_crackme['hexid']) == {'alice', 'bob'}
+    assert comment_by_id(str(first['_id']))['info'] == 'First'
+    assert comment_set_spoiler(first['_id'], True)['spoiler'] is True
+
+
+def test_solution_query_counter_and_author_helpers(app, db, sample_crackme):
+    from app.models.solution import (
+        count_solutions, count_solutions_by_crackme, count_solutions_by_user,
+        get_solution_authors, solution_by_hexid, solution_create,
+        solutions_by_crackme, solutions_by_user,
+    )
+
+    solution = solution_create('Info', 'bob', sample_crackme, content='body')
+    db.solution.update_one({'_id': solution['_id']}, {'$set': {'visible': True}})
+    assert count_solutions() == 1
+    assert count_solutions_by_user('bob') == 1
+    assert count_solutions_by_crackme(sample_crackme['hexid']) == 1
+    assert solution_by_hexid(solution['hexid'])['author'] == 'bob'
+    assert len(solutions_by_user('bob')) == 1
+    assert len(solutions_by_crackme(sample_crackme['_id'])) == 1
+    assert get_solution_authors(sample_crackme['hexid']) == {'bob'}
+
+
+def test_notification_bulk_seen_remove_and_unseen_helpers(app, db, alice):
+    from app.models.notification import (
+        notification_add, notification_remove, notifications_by_user,
+        notifications_has_unseen, notifications_set_seen,
+    )
+
+    first = notification_add('alice', 'First')
+    second = notification_add('alice', 'Second')
+    assert notifications_has_unseen('alice') is True
+    items = notifications_by_user('alice')
+    notifications_set_seen('alice', items)
+    assert notifications_has_unseen('alice') is False
+    assert db.user.find_one({'name': 'alice'})['unread_notifications'] == 0
+    notification_remove('alice', first['hexid'])
+    notification_remove('alice', second['hexid'])
+    assert db.notifications.count_documents({}) == 0
+
+
+def test_rating_query_update_and_delete_helpers(app, db, sample_crackme):
+    from app.models.rating import (
+        is_already_rated_difficulty, is_already_rated_quality,
+        rating_difficulty_by_crackme, rating_difficulty_create,
+        rating_difficulty_delete_by_crackme, rating_difficulty_set_rating,
+        rating_quality_by_crackme, rating_quality_create,
+        rating_quality_set_rating,
+    )
+
+    hexid = sample_crackme['hexid']
+    rating_difficulty_create('alice', hexid, 2)
+    rating_quality_create('alice', hexid, 3)
+    rating_difficulty_set_rating('alice', hexid, 5)
+    rating_quality_set_rating('alice', hexid, 6)
+    assert is_already_rated_difficulty('alice', hexid) is True
+    assert is_already_rated_quality('alice', hexid) is True
+    assert rating_difficulty_by_crackme(hexid)[0]['rating'] == 5
+    assert rating_quality_by_crackme(hexid)[0]['rating'] == 6
+    rating_difficulty_delete_by_crackme(hexid)
+    assert db.rating_difficulty.count_documents({}) == 0
+
+
+def test_user_visibility_counts_password_and_notification_helpers(app, db, alice):
+    from app.models.user import (
+        all_users_visible, count_users, update_user_password, user_by_hexid,
+        user_decrement_unread_notifications, user_get_unread_notifications,
+        user_increment_unread_notifications,
+    )
+
+    db.user.update_one({'name': 'alice'}, {'$set': {'hexid': str(alice['_id'])}})
+    assert count_users() == 1
+    assert len(all_users_visible()) == 1
+    assert user_by_hexid(str(alice['_id']))['name'] == 'alice'
+    user_increment_unread_notifications('alice')
+    assert user_get_unread_notifications('alice') == 1
+    user_decrement_unread_notifications('alice', 20)
+    assert user_get_unread_notifications('alice') == 0
+    update_user_password('alice', 'new-hash')
+    assert db.user.find_one({'name': 'alice'})['password'] == 'new-hash'
+
+
+def test_expired_password_reset_cleanup(app, db):
+    from app.models.password_reset import cleanup_expired_tokens
+
+    db.password_reset_tokens.insert_many([
+        {'token': 'old', 'expires_at': datetime.utcnow() - timedelta(hours=1)},
+        {'token': 'new', 'expires_at': datetime.utcnow() + timedelta(hours=1)},
+    ])
+    cleanup_expired_tokens()
+    assert db.password_reset_tokens.find_one({'token': 'old'}) is None
+    assert db.password_reset_tokens.find_one({'token': 'new'}) is not None

--- a/tests/test_onsite_writeups.py
+++ b/tests/test_onsite_writeups.py
@@ -1,0 +1,203 @@
+"""Integration coverage for onsite Markdown solution writeups."""
+
+import base64
+from io import BytesIO
+from itertools import cycle
+
+import pytest
+
+from app.controllers.solution import MAX_CONTENT_LENGTH, MIN_CONTENT_LENGTH
+from app.models.solution import solution_create
+from app.services.crypto import get_obfuscation_key_base64
+
+
+def _markdown(length=MIN_CONTENT_LENGTH):
+    prefix = '# Analysis\n\nThe challenge validates its input using this algorithm.\n\n'
+    return prefix + ('A' * max(0, length - len(prefix)))
+
+
+def _submit(client, crackme, **data):
+    return client.post(
+        f"/upload/solution/{crackme['hexid']}",
+        data=data,
+        content_type='multipart/form-data',
+    )
+
+
+def _approved_solution(db, sample_crackme, **overrides):
+    values = {
+        'info': 'A useful summary',
+        'username': 'alice',
+        'crackme': sample_crackme,
+        'content': _markdown(),
+        'original_filename': None,
+    }
+    values.update(overrides)
+    solution = solution_create(**values)
+    db.solution.update_one(
+        {'hexid': solution['hexid']},
+        {'$set': {'visible': True}},
+    )
+    solution['visible'] = True
+    return solution
+
+
+def test_authenticated_user_can_open_writeup_editor(alice_client, sample_crackme):
+    response = alice_client.get(f"/upload/solution/{sample_crackme['hexid']}")
+
+    assert response.status_code == 200
+    assert b'Writeup (Markdown)' in response.data
+    assert str(MIN_CONTENT_LENGTH).encode() in response.data
+    assert f'{MAX_CONTENT_LENGTH:,}'.encode() in response.data
+
+
+def test_legacy_editor_url_redirects_to_primary_editor(alice_client, sample_crackme):
+    response = alice_client.get(
+        f"/upload/solution/{sample_crackme['hexid']}/editor"
+    )
+
+    assert response.status_code == 302
+    assert response.location == f"/upload/solution/{sample_crackme['hexid']}"
+
+
+def test_markdown_only_writeup_is_created_pending_review(
+        alice_client, db, sample_crackme):
+    content = _markdown()
+    response = _submit(
+        alice_client,
+        sample_crackme,
+        info='Solved with static analysis',
+        content=content,
+    )
+
+    assert response.status_code == 200
+    assert b'waiting' in response.data.lower() or b'success' in response.data.lower()
+    solution = db.solution.find_one({'author': 'alice'})
+    assert solution['content'] == content
+    assert solution['original_filename'] is None
+    assert solution['has_attachment'] is False
+    assert solution['visible'] is False
+
+
+@pytest.mark.parametrize(
+    ('content', 'message'),
+    [
+        ('', b'Please write a markdown writeup or attach a file'),
+        ('A' * (MIN_CONTENT_LENGTH - 1), b'writeup is too short'),
+        ('A' * (MAX_CONTENT_LENGTH + 1), b'exceeds the maximum length'),
+    ],
+)
+def test_invalid_writeup_content_is_rejected(
+        alice_client, db, sample_crackme, content, message):
+    response = _submit(
+        alice_client,
+        sample_crackme,
+        info='Summary',
+        content=content,
+    )
+
+    assert response.status_code == 302
+    with alice_client.session_transaction() as session:
+        assert message in session['_flashes'][-1][1].encode()
+    assert db.solution.count_documents({}) == 0
+
+
+def test_writeup_at_maximum_length_is_accepted(alice_client, db, sample_crackme):
+    content = _markdown(MAX_CONTENT_LENGTH)
+
+    assert len(content) == MAX_CONTENT_LENGTH
+    assert _submit(
+        alice_client, sample_crackme, info='Summary', content=content
+    ).status_code == 200
+    assert db.solution.find_one({})['content'] == content
+
+
+def test_duplicate_writeup_is_rejected(alice_client, db, sample_crackme):
+    first = _submit(
+        alice_client, sample_crackme, info='First', content=_markdown()
+    )
+    second = _submit(
+        alice_client, sample_crackme, info='Second', content=_markdown()
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 302
+    assert db.solution.count_documents({'author': 'alice'}) == 1
+    with alice_client.session_transaction() as session:
+        assert "already submitted" in session['_flashes'][-1][1]
+
+
+def test_writeup_with_attachment_records_and_writes_attachment(
+        alice_client, db, sample_crackme, tmp_path, monkeypatch):
+    from app.controllers import solution as solution_controller
+
+    monkeypatch.setattr(solution_controller, 'UPLOAD_FOLDER', str(tmp_path))
+    response = _submit(
+        alice_client,
+        sample_crackme,
+        info='Includes a helper script',
+        content=_markdown(),
+        file=(BytesIO(b'print("helper")\n'), '../../helper.py'),
+    )
+
+    assert response.status_code == 200
+    solution = db.solution.find_one({'author': 'alice'})
+    assert solution['original_filename'] == 'helper.py'
+    assert solution['has_attachment'] is True
+    assert (tmp_path / solution['hexid']).read_bytes() == b'print("helper")\n'
+
+
+def test_approved_onsite_writeup_page_does_not_embed_raw_markdown(
+        client, db, sample_crackme):
+    content = _markdown()
+    solution = _approved_solution(db, sample_crackme, content=content)
+
+    response = client.get(f"/solution/{solution['hexid']}")
+
+    assert response.status_code == 200
+    assert b'Loading writeup' in response.data
+    assert content.encode() not in response.data
+    assert b"fetch('/solution/' + hexid + '/content')" in response.data
+
+
+def test_content_endpoint_returns_decodable_obfuscated_markdown(
+        client, app, db, sample_crackme):
+    content = _markdown() + '\n```python\nprint("solved")\n```'
+    solution = _approved_solution(db, sample_crackme, content=content)
+
+    response = client.get(f"/solution/{solution['hexid']}/content")
+
+    assert response.status_code == 200
+    assert response.mimetype == 'application/octet-stream'
+    assert content.encode() not in response.data
+    salt = app.config['APP_CONFIG']['Writeup']['ObfuscationSalt']
+    key = base64.b64decode(get_obfuscation_key_base64(solution['hexid'], salt))
+    decoded = bytes(value ^ key_byte for value, key_byte in zip(response.data, cycle(key)))
+    assert decoded.decode() == content
+
+
+def test_attachment_only_solution_has_no_content_endpoint(
+        client, db, sample_crackme):
+    solution = _approved_solution(
+        db,
+        sample_crackme,
+        content=None,
+        original_filename='analysis.pdf',
+    )
+
+    page = client.get(f"/solution/{solution['hexid']}")
+    content = client.get(f"/solution/{solution['hexid']}/content")
+
+    assert page.status_code == 200
+    assert b'This writeup is only available for download' in page.data
+    assert b'Download Archive' in page.data
+    assert content.status_code == 404
+
+
+def test_pending_writeup_is_not_public(client, db, sample_crackme):
+    solution = solution_create(
+        'Summary', 'alice', sample_crackme, content=_markdown()
+    )
+
+    assert client.get(f"/solution/{solution['hexid']}").status_code == 404
+    assert client.get(f"/solution/{solution['hexid']}/content").status_code == 404

--- a/tests/test_password_reset.py
+++ b/tests/test_password_reset.py
@@ -1,0 +1,78 @@
+"""Password-reset tests with email and Discord kept behind mocks."""
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from app.models.password_reset import create_reset_token
+from app.services.passhash import match_string
+
+
+def test_forgot_password_sends_configured_reset_link(client, db, alice):
+    with patch('app.controllers.password_reset.email_is_configured', return_value=True), \
+         patch('app.controllers.password_reset.send_email', return_value=True) as send, \
+         patch('app.controllers.password_reset.notify_password_reset_request'):
+        response = client.post(
+            '/forgot-password', data={'email': 'alice@example.test'}
+        )
+
+    assert response.status_code == 200
+    assert b'email' in response.data.lower()
+    token = db.password_reset_tokens.find_one({'email': 'alice@example.test'})['token']
+    recipient, subject, body = send.call_args.args
+    assert recipient == 'alice@example.test'
+    assert 'Password Reset' in subject
+    assert f'http://localhost/reset-password/{token}' in body
+
+
+def test_forgot_password_does_not_reveal_unknown_email(client, db):
+    with patch('app.controllers.password_reset.email_is_configured', return_value=True), \
+         patch('app.controllers.password_reset.send_email') as send:
+        response = client.post(
+            '/forgot-password', data={'email': 'missing@example.test'}
+        )
+
+    assert response.status_code == 200
+    assert b'email' in response.data.lower()
+    send.assert_not_called()
+
+
+def test_valid_reset_token_changes_password_and_is_single_use(client, db, alice):
+    token = create_reset_token('alice@example.test')
+    with patch('app.controllers.password_reset.notify_password_reset_complete'):
+        response = client.post(f'/reset-password/{token}', data={
+            'new_password': 'replacement-password',
+            'new_password_verify': 'replacement-password',
+        })
+
+    assert response.status_code == 302
+    assert response.location == '/login'
+    assert match_string(
+        db.user.find_one({'name': 'alice'})['password'], 'replacement-password'
+    ) is True
+    assert db.password_reset_tokens.find_one({'token': token}) is None
+    assert client.get(f'/reset-password/{token}').status_code == 302
+
+
+def test_expired_reset_token_is_rejected(client, db, alice):
+    db.password_reset_tokens.insert_one({
+        'email': 'alice@example.test',
+        'token': 'expired-token',
+        'expires_at': datetime.utcnow() - timedelta(minutes=1),
+    })
+
+    response = client.get('/reset-password/expired-token')
+
+    assert response.status_code == 302
+    assert response.location == '/forgot-password'
+
+
+def test_reset_password_validates_confirmation(client, db, alice):
+    token = create_reset_token('alice@example.test')
+    response = client.post(f'/reset-password/{token}', data={
+        'new_password': 'replacement-password',
+        'new_password_verify': 'different-password',
+    })
+
+    assert response.status_code == 200
+    assert b'Passwords do not match' in response.data
+    assert db.password_reset_tokens.find_one({'token': token}) is not None

--- a/tests/test_recaptcha.py
+++ b/tests/test_recaptcha.py
@@ -1,52 +1,52 @@
-"""
-Unit tests for reCAPTCHA service.
-"""
-import pytest
-from unittest.mock import patch, MagicMock
-from app.services.recaptcha import verify_recaptcha
+"""Unit tests for the reCAPTCHA external-service boundary."""
+
+from unittest.mock import MagicMock, patch
+
+from flask import request
+
+from app.services.recaptcha import init_recaptcha, verify
 
 
-class TestRecaptcha:
-    """Tests for reCAPTCHA verification."""
+def test_disabled_recaptcha_passes(app):
+    init_recaptcha(app, {'Enabled': False})
+    with app.test_request_context('/register', method='POST'):
+        assert verify(request) is True
 
-    def test_verify_recaptcha_disabled(self):
-        """Test that verification passes when reCAPTCHA is disabled."""
-        config = {'Recaptcha': {'Enabled': False}}
-        with patch('app.services.recaptcha.load_config', return_value=config):
-            from app.services import recaptcha
-            # Reload to pick up the mock
-            result = verify_recaptcha('any-token')
-            # When disabled, should return True
-            assert result is True
 
-    def test_verify_recaptcha_empty_token(self):
-        """Test verification with empty token."""
-        config = {'Recaptcha': {'Enabled': True, 'Secret': 'test-secret'}}
-        with patch('app.services.recaptcha.load_config', return_value=config):
-            with patch('app.services.recaptcha.RECAPTCHA_ENABLED', True):
-                result = verify_recaptcha('')
-                assert result is False
+def test_enabled_recaptcha_rejects_missing_token(app):
+    init_recaptcha(app, {'Enabled': True, 'Secret': 'test-secret'})
+    with app.test_request_context('/register', method='POST'):
+        assert verify(request) is False
 
-    def test_verify_recaptcha_success(self):
-        """Test successful reCAPTCHA verification."""
-        config = {'Recaptcha': {'Enabled': True, 'Secret': 'test-secret'}}
-        mock_response = MagicMock()
-        mock_response.json.return_value = {'success': True}
 
-        with patch('app.services.recaptcha.load_config', return_value=config):
-            with patch('app.services.recaptcha.RECAPTCHA_ENABLED', True):
-                with patch('app.services.recaptcha.requests.post', return_value=mock_response):
-                    result = verify_recaptcha('valid-token')
-                    assert result is True
+def test_enabled_recaptcha_sends_token_and_accepts_success(app):
+    init_recaptcha(app, {'Enabled': True, 'Secret': 'test-secret'})
+    response = MagicMock()
+    response.json.return_value = {'success': True}
 
-    def test_verify_recaptcha_failure(self):
-        """Test failed reCAPTCHA verification."""
-        config = {'Recaptcha': {'Enabled': True, 'Secret': 'test-secret'}}
-        mock_response = MagicMock()
-        mock_response.json.return_value = {'success': False}
+    with app.test_request_context(
+        '/register', method='POST',
+        data={'g-recaptcha-response': 'valid-token'},
+        environ_base={'REMOTE_ADDR': '127.0.0.1'},
+    ):
+        with patch('app.services.recaptcha.requests.post', return_value=response) as post:
+            assert verify(request) is True
 
-        with patch('app.services.recaptcha.load_config', return_value=config):
-            with patch('app.services.recaptcha.RECAPTCHA_ENABLED', True):
-                with patch('app.services.recaptcha.requests.post', return_value=mock_response):
-                    result = verify_recaptcha('invalid-token')
-                    assert result is False
+    post.assert_called_once_with(
+        'https://www.google.com/recaptcha/api/siteverify',
+        data={
+            'secret': 'test-secret',
+            'response': 'valid-token',
+            'remoteip': '127.0.0.1',
+        },
+        timeout=10,
+    )
+
+
+def test_enabled_recaptcha_fails_closed_on_network_error(app):
+    init_recaptcha(app, {'Enabled': True, 'Secret': 'test-secret'})
+    with app.test_request_context(
+        '/register', method='POST', data={'g-recaptcha-response': 'token'}
+    ):
+        with patch('app.services.recaptcha.requests.post', side_effect=TimeoutError):
+            assert verify(request) is False

--- a/tests/test_remaining_utils.py
+++ b/tests/test_remaining_utils.py
@@ -1,0 +1,98 @@
+"""Remaining deterministic utility branches suitable for isolated testing."""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+
+def test_limiter_decorator_helpers_with_and_without_instance(monkeypatch):
+    from app.services import limiter as service
+
+    monkeypatch.setattr(service, 'limiter', None)
+    function = lambda: 'ok'
+    assert service.limit('1/minute')(function)() == 'ok'
+    assert service.shared_limit('1/minute', scope='x')(function)() == 'ok'
+    assert service.exempt(function) is function
+
+    fake = MagicMock()
+    fake.limit.return_value = lambda fn: fn
+    fake.shared_limit.return_value = lambda fn: fn
+    fake.exempt.return_value = function
+    monkeypatch.setattr(service, 'limiter', fake)
+    assert service.limit('1/minute')(function)() == 'ok'
+    assert service.shared_limit('1/minute', scope='x')(function)() == 'ok'
+    assert service.exempt(function) is function
+
+
+def test_recaptcha_configuration_accessors(app):
+    from app.services import recaptcha
+
+    recaptcha.init_recaptcha(app, {
+        'Enabled': True, 'SiteKey': 'site-key', 'Secret': 'secret',
+    })
+    assert recaptcha.read_config()['Secret'] == 'secret'
+    assert recaptcha.is_enabled() is True
+    assert recaptcha.get_site_key() == 'site-key'
+    recaptcha.init_recaptcha(app, {'Enabled': False})
+    assert recaptcha.get_site_key() == ''
+
+
+def test_crypto_default_salt_and_key_are_deterministic():
+    from app.services.crypto import (
+        DEFAULT_OBFUSCATION_SALT, get_obfuscation_key_base64,
+        get_obfuscation_salt, obfuscate_writeup,
+    )
+
+    assert get_obfuscation_salt({}) == DEFAULT_OBFUSCATION_SALT
+    key1 = get_obfuscation_key_base64('abc', 'salt')
+    key2 = get_obfuscation_key_base64('abc', 'salt')
+    assert key1 == key2
+    assert obfuscate_writeup('hello', 'abc', 'salt') != b'hello'
+
+
+def test_database_access_and_failed_health_check(app, monkeypatch):
+    from app.services import database
+    from pymongo.errors import ConnectionFailure
+
+    assert database.get_db() is app.config['MONGO_DB']
+    assert database.get_collection('user').name == 'user'
+    failing = MagicMock()
+    failing.admin.command.side_effect = ConnectionFailure('down')
+    monkeypatch.setattr(database, 'mongo_client', failing)
+    assert database.check_connection() is False
+    monkeypatch.setattr(database, 'mongo_client', None)
+    assert database.check_connection() is False
+
+
+def test_remaining_template_filter_fallbacks(app):
+    filters = app.jinja_env.filters
+    globals_ = app.jinja_env.globals
+    assert filters['PRETTYTIME'](None) == ''
+    assert filters['PRETTYTIME'](object()) == ''
+    assert filters['PRETTYTIMEFORMAT'](None, '%Y') == ''
+    assert filters['PRETTYTIMEFORMAT'](object(), '%Y') == ''
+    assert filters['TIMECOMPARE'](None, datetime.now()) is False
+    assert filters['render_mentions']('') == ''
+    assert globals_['TIMECOMPARE'](None, None, 2) is True
+    assert globals_['TIMECOMPARE']('bad', 'values', 2) is True
+    assert globals_['DIFFERENT_DATE'](None, None) is True
+    assert globals_['DIFFERENT_DATE']('bad', 'values') is True
+
+
+def test_archive_malformed_compressed_signatures_and_pe_offsets():
+    from app.services.archive import is_archive_password_protected, is_pe_file, is_tar_file
+
+    assert is_tar_file(b'\x1f\x8bnot-gzip') is False
+    assert is_tar_file(b'BZhnot-bzip') is False
+    assert is_tar_file(b'\xfd7zXZ\x00not-xz') is False
+    header = bytearray(80)
+    header[:2] = b'MZ'
+    header[0x3C:0x40] = (9999).to_bytes(4, 'little')
+    assert is_pe_file('file.bin', bytes(header)) is False
+    assert is_archive_password_protected(b'not-a-zip') is False
+
+
+def test_user_and_solution_error_routes(client):
+    assert client.get('/user/missing').status_code == 404
+    assert client.get('/solution/not-valid').status_code == 404
+    assert client.get('/solution/not-valid/content').status_code == 404
+    assert client.get('/upload/solution/not-valid').status_code == 302

--- a/tests/test_reviewer_admin.py
+++ b/tests/test_reviewer_admin.py
@@ -1,0 +1,71 @@
+"""Authorization and mutation tests for reviewer administration."""
+
+
+def _admin_client(app):
+    from review import routes
+
+    routes.users['admin'] = {
+        'password_hash': routes.hash_string('admin-passwordtest-reviewer-salt'),
+        'is_admin': True,
+    }
+    client = app.test_client()
+    with client.session_transaction() as session:
+        session['_reviewer_user'] = 'admin'
+        session['_reviewer_is_admin'] = True
+        session['_reviewer_csrf_token'] = 'admin-csrf'
+    return client
+
+
+def test_regular_reviewer_cannot_manage_reviewer_accounts(reviewer_client):
+    assert reviewer_client.get('/review/managereviewers').status_code == 403
+
+
+def test_admin_can_add_reviewer(app, db, monkeypatch):
+    from review import routes
+
+    client = _admin_client(app)
+    monkeypatch.setattr(routes, 'save_users', lambda: None)
+    monkeypatch.setattr(routes, 'log_reviewer_operation', lambda *a, **k: None)
+
+    response = client.post('/review/managereviewers', data={
+        'csrf_token': 'admin-csrf',
+        'action': 'add',
+        'new_username': 'new-reviewer',
+        'new_password': 'reviewer-secret',
+    })
+
+    assert response.status_code == 200
+    assert b"Reviewer &#39;new-reviewer&#39; added successfully" in response.data
+    assert routes.users['new-reviewer']['is_admin'] is False
+    assert routes.users['new-reviewer']['password_hash'] == routes.hash_string(
+        'reviewer-secrettest-reviewer-salt'
+    )
+    routes.users.pop('new-reviewer', None)
+    routes.users.pop('admin', None)
+
+
+def test_admin_management_post_requires_csrf(app, db):
+    from review import routes
+
+    client = _admin_client(app)
+    response = client.post('/review/managereviewers', data={'action': 'add'})
+
+    assert response.status_code == 403
+    routes.users.pop('admin', None)
+
+
+def test_admin_cannot_delete_own_reviewer_account(app, db, monkeypatch):
+    from review import routes
+
+    client = _admin_client(app)
+    monkeypatch.setattr(routes, 'save_users', lambda: None)
+    response = client.post('/review/managereviewers', data={
+        'csrf_token': 'admin-csrf',
+        'action': 'delete',
+        'username_to_delete': 'admin',
+    })
+
+    assert response.status_code == 200
+    assert b'cannot delete your own account' in response.data
+    assert 'admin' in routes.users
+    routes.users.pop('admin', None)

--- a/tests/test_reviewer_auth.py
+++ b/tests/test_reviewer_auth.py
@@ -1,0 +1,46 @@
+"""Unit coverage for the isolated reviewer authentication domain."""
+
+from review import auth
+
+
+def test_reviewer_authentication_and_stale_sessions(app):
+    accounts = {'reviewer': {'is_admin': False}, 'admin': {'is_admin': True}}
+    auth.configure(accounts)
+
+    with app.test_request_context('/'):
+        assert auth.get_current_reviewer() is None
+        auth.session[auth.REVIEWER_SESSION_KEY] = 'removed-user'
+        assert auth.get_current_reviewer() is None
+        auth.session[auth.REVIEWER_SESSION_KEY] = 'admin'
+        assert auth.get_current_reviewer() == {
+            'username': 'admin', 'is_admin': True
+        }
+
+
+def test_reviewer_csrf_token_is_stable_and_validated(app):
+    with app.test_request_context(
+        '/', method='POST', data={'csrf_token': 'known-token'}
+    ):
+        auth.session[auth.REVIEWER_CSRF_KEY] = 'known-token'
+        assert auth.generate_csrf_token() == 'known-token'
+        assert auth.validate_csrf_token() is None
+
+
+def test_reviewer_csrf_token_is_generated(app):
+    with app.test_request_context('/'):
+        token = auth.generate_csrf_token()
+        assert len(token) == 64
+        assert auth.generate_csrf_token() == token
+
+
+def test_clear_reviewer_session_preserves_main_site_session(app):
+    with app.test_request_context('/'):
+        auth.session.update({
+            auth.REVIEWER_SESSION_KEY: 'reviewer',
+            auth.REVIEWER_ADMIN_KEY: False,
+            'name': 'alice',
+        })
+        auth.clear_reviewer_session()
+        assert auth.REVIEWER_SESSION_KEY not in auth.session
+        assert auth.REVIEWER_ADMIN_KEY not in auth.session
+        assert auth.session['name'] == 'alice'

--- a/tests/test_reviewer_logger.py
+++ b/tests/test_reviewer_logger.py
@@ -1,0 +1,66 @@
+"""Unit tests for reviewer audit logging and Discord delivery."""
+
+from unittest.mock import MagicMock, patch
+
+from review import logger
+
+
+def test_successful_and_failed_operations_use_correct_log_levels():
+    with patch.object(logger.logger, 'info') as info, \
+         patch.object(logger.logger, 'error') as error:
+        logger.init_logger(None)
+        logger.log_reviewer_operation('approve_solution', 'reviewer', {'id': '1'})
+        logger.log_reviewer_operation(
+            'delete_solution', 'reviewer', {'id': '2'}, success=False
+        )
+
+    info.assert_called_once()
+    error.assert_called_once()
+    assert 'Status: SUCCESS' in info.call_args.args[0]
+    assert 'Status: FAILED' in error.call_args.args[0]
+
+
+def test_operation_logging_sends_configured_discord_webhook():
+    logger.init_logger('https://discord.example.test/webhook')
+    with patch.object(logger, 'send_discord_log') as send, \
+         patch.object(logger.logger, 'info'):
+        logger.log_reviewer_operation(
+            'approve_solution', 'reviewer', {'solution': 'abc'}, True
+        )
+
+    send.assert_called_once_with(
+        'approve_solution', 'reviewer', {'solution': 'abc'}, True
+    )
+    logger.init_logger(None)
+
+
+def test_discord_log_payload_and_colors():
+    logger.init_logger('https://discord.example.test/webhook')
+    response = MagicMock(status_code=204)
+    with patch.object(logger.requests, 'post', return_value=response) as post:
+        logger.send_discord_log(
+            'approve_solution', 'reviewer', {'solution': 'abc'}, True
+        )
+
+    url, = post.call_args.args
+    payload = post.call_args.kwargs['json']['embeds'][0]
+    assert url == 'https://discord.example.test/webhook'
+    assert payload['color'] == 65280
+    assert payload['fields'][0]['value'] == '✅ Success'
+    assert '**solution:** abc' in payload['fields'][1]['value']
+    logger.init_logger(None)
+
+
+def test_discord_log_warns_on_http_failure_and_network_error():
+    logger.init_logger('https://discord.example.test/webhook')
+    with patch.object(
+        logger.requests, 'post', return_value=MagicMock(status_code=500)
+    ), patch.object(logger.logger, 'warning') as warning:
+        logger.send_discord_log('delete_user', 'admin', {}, True)
+        assert warning.called
+
+    with patch.object(logger.requests, 'post', side_effect=TimeoutError), \
+         patch.object(logger.logger, 'warning') as warning:
+        logger.send_discord_log('other_action', 'admin', {}, False)
+        assert warning.called
+    logger.init_logger(None)

--- a/tests/test_reviewer_operations.py
+++ b/tests/test_reviewer_operations.py
@@ -1,0 +1,159 @@
+"""Operational reviewer coverage for crackmes, deletion, and user tools."""
+
+from bson import ObjectId
+
+
+def _review_dirs(monkeypatch, tmp_path):
+    from review import routes
+
+    pending = tmp_path / 'pending'
+    approved = tmp_path / 'approved'
+    pending.mkdir()
+    approved.mkdir()
+    monkeypatch.setattr(
+        routes, 'get_tmp_dir', lambda item_type: str(pending / item_type)
+    )
+    monkeypatch.setattr(
+        routes, 'get_static_dir', lambda item_type: str(approved / item_type)
+    )
+    (pending / 'crackme').mkdir()
+    (pending / 'solution').mkdir()
+    (approved / 'crackme').mkdir()
+    (approved / 'solution').mkdir()
+    return pending, approved
+
+
+def test_reviewer_approves_pending_crackme(
+        reviewer_client, db, sample_crackme, monkeypatch, tmp_path):
+    from review import routes
+
+    pending, _ = _review_dirs(monkeypatch, tmp_path)
+    db.crackme.update_one(
+        {'_id': sample_crackme['_id']}, {'$set': {'visible': False}}
+    )
+    (pending / 'crackme' / sample_crackme['hexid']).write_bytes(b'binary')
+    monkeypatch.setattr(
+        routes, 'create_password_protected_zip', lambda *args: (True, None)
+    )
+    monkeypatch.setattr(routes, 'notify_crackme_approved', lambda *args: None)
+    monkeypatch.setattr(routes, 'log_reviewer_operation', lambda *args, **kw: None)
+
+    response = reviewer_client.post('/review/approvecrackme', data={
+        'uuid': sample_crackme['hexid'], 'csrf_token': 'test-csrf-token',
+    })
+
+    assert response.status_code == 302
+    assert db.crackme.find_one({'_id': sample_crackme['_id']})['visible'] is True
+    assert db.notifications.count_documents({'user': 'alice'}) == 1
+
+
+def test_reviewer_rejects_pending_crackme_and_removes_ratings(
+        reviewer_client, db, sample_crackme, monkeypatch, tmp_path):
+    from review import routes
+
+    pending, _ = _review_dirs(monkeypatch, tmp_path)
+    db.crackme.update_one(
+        {'_id': sample_crackme['_id']}, {'$set': {'visible': False}}
+    )
+    db.rating_difficulty.insert_one({'crackmehexid': sample_crackme['hexid']})
+    db.rating_quality.insert_one({'crackmehexid': sample_crackme['hexid']})
+    pending_file = pending / 'crackme' / sample_crackme['hexid']
+    pending_file.write_bytes(b'binary')
+    monkeypatch.setattr(routes, 'log_reviewer_operation', lambda *args, **kw: None)
+
+    response = reviewer_client.post('/review/rejectcrackme', data={
+        'uuid': sample_crackme['hexid'],
+        'reject_reason': 'Does not follow the rules',
+        'csrf_token': 'test-csrf-token',
+    })
+
+    assert response.status_code == 302
+    assert db.crackme.find_one({'_id': sample_crackme['_id']}) is None
+    assert db.rating_difficulty.count_documents({}) == 0
+    assert db.rating_quality.count_documents({}) == 0
+    assert pending_file.exists() is False
+    assert 'Does not follow the rules' in db.notifications.find_one({})['text']
+
+
+def test_crackme_approval_rolls_back_when_archive_creation_fails(
+        db, sample_crackme, monkeypatch, tmp_path):
+    from review import routes
+
+    pending, _ = _review_dirs(monkeypatch, tmp_path)
+    db.crackme.update_one(
+        {'_id': sample_crackme['_id']}, {'$set': {'visible': False}}
+    )
+    (pending / 'crackme' / sample_crackme['hexid']).write_bytes(b'binary')
+    monkeypatch.setattr(
+        routes, 'create_password_protected_zip',
+        lambda *args: (False, 'compression failed'),
+    )
+
+    success, message = routes.approve_pending_crackme(sample_crackme['hexid'])
+
+    assert success is False
+    assert message == 'compression failed'
+    assert db.crackme.find_one({'_id': sample_crackme['_id']})['visible'] is False
+
+
+def test_admin_cascade_deletes_crackme_related_data(
+        db, sample_crackme, monkeypatch, tmp_path):
+    from review import routes
+
+    _, approved = _review_dirs(monkeypatch, tmp_path)
+    solution_id = ObjectId()
+    db.solution.insert_one({
+        '_id': solution_id, 'hexid': str(solution_id),
+        'crackmeid': sample_crackme['_id'],
+    })
+    db.comment.insert_one({'crackmehexid': sample_crackme['hexid']})
+    db.rating_difficulty.insert_one({'crackmehexid': sample_crackme['hexid']})
+    db.rating_quality.insert_one({'crackmehexid': sample_crackme['hexid']})
+    (approved / 'crackme' / f"{sample_crackme['hexid']}.zip").write_bytes(b'zip')
+
+    message = routes.delete_approved_crackme(sample_crackme['hexid'])
+
+    assert '1 solutions' in message
+    assert '1 comments' in message
+    assert db.crackme.count_documents({}) == 0
+    assert db.solution.count_documents({}) == 0
+    assert db.comment.count_documents({}) == 0
+    assert db.rating_difficulty.count_documents({}) == 0
+    assert db.rating_quality.count_documents({}) == 0
+
+
+def test_admin_deletes_approved_solution_and_decrements_count(
+        db, sample_crackme, monkeypatch, tmp_path):
+    from review import routes
+
+    _, approved = _review_dirs(monkeypatch, tmp_path)
+    solution_id = ObjectId()
+    db.solution.insert_one({
+        '_id': solution_id, 'hexid': str(solution_id),
+        'crackmeid': sample_crackme['_id'],
+    })
+    db.crackme.update_one(
+        {'_id': sample_crackme['_id']}, {'$set': {'nbsolutions': 1}}
+    )
+    archive = approved / 'solution' / f'{solution_id}.zip'
+    archive.write_bytes(b'zip')
+
+    assert routes.delete_approved_solution(str(solution_id)) == 'Solution deleted'
+    assert db.solution.count_documents({}) == 0
+    assert db.crackme.find_one({'_id': sample_crackme['_id']})['nbsolutions'] == 0
+    assert archive.exists() is False
+
+
+def test_admin_user_lookup_and_password_reset_helpers(db, alice, monkeypatch):
+    from review import routes
+
+    monkeypatch.setattr(routes.random, 'choices', lambda *args, **kw: list('A' * 16))
+    found = routes.find_user_by_email_or_name('ALICE@EXAMPLE.TEST')
+    reset_message = routes.reset_user_password('alice@example.test')
+    preview, error = routes.preview_user_deletion('alice@example.test')
+
+    assert found['name'] == 'alice'
+    assert 'Password reset successful' in reset_message
+    assert 'New password: AAAAAAAAAAAAAAAA' in reset_message
+    assert error is None
+    assert preview['username'] == 'alice'

--- a/tests/test_reviewer_remaining.py
+++ b/tests/test_reviewer_remaining.py
@@ -1,0 +1,272 @@
+"""Coverage for the remaining reviewer administration and archive workflows."""
+
+import json
+from datetime import datetime, timezone
+from io import BytesIO
+
+from bson import ObjectId
+
+
+def _admin_client(app):
+    from review import auth, routes
+
+    routes.users['workflow-admin'] = {'password_hash': 'unused', 'is_admin': True}
+    auth.configure(routes.users)
+    client = app.test_client()
+    with client.session_transaction() as session:
+        session['_reviewer_user'] = 'workflow-admin'
+        session['_reviewer_is_admin'] = True
+        session['_reviewer_csrf_token'] = 'workflow-csrf'
+    return client
+
+
+def _cleanup_admin():
+    from review import routes
+    routes.users.pop('workflow-admin', None)
+
+
+def test_reviewer_downloads_pending_attachment(
+        reviewer_client, db, sample_crackme, monkeypatch, tmp_path):
+    from review import routes
+
+    pending = tmp_path / 'solution'
+    pending.mkdir()
+    file_path = pending / sample_crackme['hexid']
+    file_path.write_bytes(b'pending attachment')
+    db.solution.insert_one({
+        'hexid': sample_crackme['hexid'], 'original_filename': 'analysis.txt'
+    })
+    monkeypatch.setattr(routes, 'get_tmp_dir', lambda kind: str(pending))
+
+    response = reviewer_client.get(
+        f"/review/downloadreview?type=solution&uuid={sample_crackme['hexid']}"
+    )
+
+    assert response.status_code == 200
+    assert response.data == b'pending attachment'
+    assert 'analysis.txt' in response.headers['Content-Disposition']
+    assert reviewer_client.get('/review/downloadreview?type=bad&uuid=x').status_code == 404
+
+
+def test_admin_edits_crackme_metadata_and_notifies_author(
+        app, db, sample_crackme, monkeypatch):
+    from review import routes
+
+    client = _admin_client(app)
+    monkeypatch.setattr(routes, 'log_reviewer_operation', lambda *a, **k: None)
+    response = client.post('/review/editcrackme', data={
+        'csrf_token': 'workflow-csrf',
+        'crackme_uuid': sample_crackme['hexid'],
+        'info': 'Reviewer-updated description',
+        'lang': 'Rust', 'arch': 'ARM', 'platform': 'Linux',
+        'notify_author': 'on',
+    })
+
+    assert response.status_code == 200
+    updated = db.crackme.find_one({'_id': sample_crackme['_id']})
+    assert updated['info'] == 'Reviewer-updated description'
+    assert updated['lang'] == 'Rust'
+    assert db.notifications.count_documents({'user': 'alice'}) == 1
+    _cleanup_admin()
+
+
+def test_admin_replaces_crackme_file(app, db, sample_crackme, monkeypatch, tmp_path):
+    from review import routes
+
+    client = _admin_client(app)
+    monkeypatch.setattr(routes, 'CRACKMESONE_DIR', str(tmp_path))
+    monkeypatch.setattr(routes, 'get_static_dir', lambda kind: str(tmp_path))
+    monkeypatch.setattr(routes, 'log_reviewer_operation', lambda *a, **k: None)
+    monkeypatch.setattr(
+        routes, 'create_password_protected_zip', lambda *a: (True, None)
+    )
+    response = client.post('/review/editcrackme', data={
+        'csrf_token': 'workflow-csrf', 'crackme_uuid': sample_crackme['hexid'],
+        'info': sample_crackme['info'], 'lang': sample_crackme['lang'],
+        'arch': sample_crackme['arch'], 'platform': sample_crackme['platform'],
+        'file': (BytesIO(b'replacement'), 'replacement.bin'),
+    }, content_type='multipart/form-data')
+
+    assert response.status_code == 200
+    assert b'updated successfully' in response.data
+    _cleanup_admin()
+
+
+def test_admin_lists_toggles_and_deletes_comments(
+        app, db, sample_crackme, bob, monkeypatch):
+    from review import routes
+
+    client = _admin_client(app)
+    comment_id = ObjectId()
+    db.comment.insert_one({
+        '_id': comment_id, 'author': 'bob', 'info': 'Moderate me',
+        'crackmehexid': sample_crackme['hexid'], 'spoiler': False,
+    })
+    db.crackme.update_one({'_id': sample_crackme['_id']}, {'$set': {'nbcomments': 1}})
+    monkeypatch.setattr(routes, 'log_reviewer_operation', lambda *a, **k: None)
+
+    listing = client.get(f"/review/delcomment?crackme_uuid={sample_crackme['hexid']}")
+    toggled = client.post('/review/delcomment', data={
+        'csrf_token': 'workflow-csrf', 'crackme_uuid': sample_crackme['hexid'],
+        'comment_uuid': str(comment_id), 'action': 'toggle_spoiler',
+    })
+    deleted = client.post('/review/delcomment', data={
+        'csrf_token': 'workflow-csrf', 'crackme_uuid': sample_crackme['hexid'],
+        'comment_uuid': str(comment_id), 'action': 'delete',
+    })
+
+    assert listing.status_code == toggled.status_code == deleted.status_code == 200
+    assert b'Moderate me' in listing.data
+    assert db.comment.find_one({'_id': comment_id}) is None
+    assert db.crackme.find_one({'_id': sample_crackme['_id']})['nbcomments'] == 0
+    _cleanup_admin()
+
+
+def test_full_user_lookup_and_delete_preview(app, db, alice, sample_crackme, monkeypatch):
+    from review import routes
+
+    client = _admin_client(app)
+    db.comment.insert_one({
+        'author': 'alice', 'info': 'A' * 120,
+        'crackmehexid': sample_crackme['hexid'], 'created_at': datetime.now(timezone.utc),
+    })
+    db.rating_difficulty.insert_one({
+        'author': 'alice', 'rating': 3, 'crackmehexid': sample_crackme['hexid'],
+        'created_at': datetime.now(timezone.utc),
+    })
+    monkeypatch.setattr(routes, 'log_reviewer_operation', lambda *a, **k: None)
+    lookup = client.post('/review/lookupuser', data={
+        'csrf_token': 'workflow-csrf', 'search_query': 'alice', 'show_all': '1',
+    })
+    preview = client.post('/review/deleteuser', data={
+        'csrf_token': 'workflow-csrf', 'action': 'preview',
+        'user_email': 'alice@example.test', 'confirm_email': 'alice@example.test',
+    })
+
+    assert lookup.status_code == preview.status_code == 200
+    assert b'alice@example.test' in lookup.data
+    assert b'Test Crackme' in lookup.data
+    assert b'alice' in preview.data
+    _cleanup_admin()
+
+
+def test_delete_user_account_removes_owned_data(db, alice, monkeypatch, tmp_path):
+    from review import routes
+
+    monkeypatch.setattr(routes, 'get_static_dir', lambda kind: str(tmp_path))
+    monkeypatch.setattr(routes, 'log_reviewer_operation', lambda *a, **k: None)
+    db.notifications.insert_one({'user': 'alice'})
+    db.comment.insert_one({'author': 'alice', 'crackmehexid': 'other'})
+    db.rating_difficulty.insert_one({'author': 'alice', 'crackmehexid': 'other'})
+    db.rating_quality.insert_one({'author': 'alice', 'crackmehexid': 'other'})
+
+    message = routes.delete_user_account('alice@example.test', 'workflow-admin')
+
+    assert 'deletion successful' in message.lower()
+    assert db.user.find_one({'name': 'alice'}) is None
+    assert db.notifications.count_documents({'user': 'alice'}) == 0
+    assert db.comment.count_documents({'author': 'alice'}) == 0
+
+
+def test_admin_deletes_toggles_and_changes_reviewer(app, db, monkeypatch):
+    from review import routes
+
+    client = _admin_client(app)
+    routes.users['target-reviewer'] = {'password_hash': 'old', 'is_admin': False}
+    monkeypatch.setattr(routes, 'save_users', lambda: None)
+    monkeypatch.setattr(routes, 'log_reviewer_operation', lambda *a, **k: None)
+
+    toggle = client.post('/review/managereviewers', data={
+        'csrf_token': 'workflow-csrf', 'action': 'toggle_admin',
+        'username_to_toggle': 'target-reviewer',
+    })
+    change = client.post('/review/managereviewers', data={
+        'csrf_token': 'workflow-csrf', 'action': 'change_password',
+        'username_to_change': 'target-reviewer', 'change_password': 'new-secret',
+    })
+    delete = client.post('/review/managereviewers', data={
+        'csrf_token': 'workflow-csrf', 'action': 'delete',
+        'username_to_delete': 'target-reviewer',
+    })
+
+    assert toggle.status_code == change.status_code == delete.status_code == 200
+    assert 'target-reviewer' not in routes.users
+    _cleanup_admin()
+
+
+def _archive_paths(monkeypatch, tmp_path):
+    from review import routes
+
+    archive_dir = tmp_path / 'archive'
+    archive_dir.mkdir()
+    monkeypatch.setattr(routes, 'ARCHIVE_DIR', str(archive_dir))
+    monkeypatch.setattr(routes, 'ARCHIVE_STATUS_FILE', str(archive_dir / 'status.json'))
+    monkeypatch.setattr(routes, 'CRACKMESONE_DIR', str(tmp_path))
+    return archive_dir
+
+
+def test_site_archive_helpers_and_path_validation(db, monkeypatch, tmp_path):
+    from review import routes
+
+    archive_dir = _archive_paths(monkeypatch, tmp_path)
+    assert routes.get_archive_status() == {'status': 'idle'}
+    routes.set_archive_status('running', step='Testing')
+    assert routes.get_archive_status()['step'] == 'Testing'
+    archive = archive_dir / 'crackmesone_20260101_000000.zip'
+    archive.write_bytes(b'zip')
+    assert routes.get_archive_list()[0]['filename'] == archive.name
+    assert routes.delete_archive('../bad.zip')[0] is False
+    assert routes.delete_archive(archive.name)[0] is True
+    routes.clear_archive_status()
+    assert routes.get_archive_status() == {'status': 'idle'}
+
+
+def test_site_archive_background_success_and_failure(
+        db, sample_crackme, monkeypatch, tmp_path):
+    from review import routes
+
+    archive_dir = _archive_paths(monkeypatch, tmp_path)
+    monkeypatch.setattr(routes, 'log_reviewer_operation', lambda *a, **k: None)
+    routes.create_site_archive_background('workflow-admin')
+    status = routes.get_archive_status()
+    assert status['status'] == 'completed'
+    assert (archive_dir / status['filename']).exists()
+
+    monkeypatch.setattr('app.services.database.get_db', lambda: None)
+    routes.create_site_archive_background('workflow-admin')
+    assert routes.get_archive_status()['status'] == 'error'
+
+
+def test_site_archive_routes_start_poll_download_and_delete(
+        app, db, monkeypatch, tmp_path):
+    from review import routes
+
+    client = _admin_client(app)
+    archive_dir = _archive_paths(monkeypatch, tmp_path)
+    archive = archive_dir / 'crackmesone_test.zip'
+    archive.write_bytes(b'archive')
+    monkeypatch.setattr(routes, 'log_reviewer_operation', lambda *a, **k: None)
+
+    class ImmediateThread:
+        daemon = False
+        def __init__(self, target, args):
+            self.target, self.args = target, args
+        def start(self):
+            routes.set_archive_status('completed', filename='created.zip')
+
+    monkeypatch.setattr(routes.threading, 'Thread', ImmediateThread)
+    started = client.post('/review/sitearchive', data={
+        'csrf_token': 'workflow-csrf', 'action': 'create',
+    })
+    status = client.get('/review/sitearchive/status')
+    download = client.get('/review/downloadarchive/crackmesone_test.zip')
+    deleted = client.post('/review/sitearchive', data={
+        'csrf_token': 'workflow-csrf', 'action': 'delete',
+        'filename': 'crackmesone_test.zip',
+    })
+
+    assert started.status_code == status.status_code == download.status_code == deleted.status_code == 200
+    assert json.loads(status.data)['status'] == 'completed'
+    assert download.data == b'archive'
+    assert archive.exists() is False
+    _cleanup_admin()

--- a/tests/test_reviewer_writeups.py
+++ b/tests/test_reviewer_writeups.py
@@ -1,0 +1,147 @@
+"""Reviewer workflow coverage for onsite writeups."""
+
+import json
+
+from app.controllers.solution import MIN_CONTENT_LENGTH
+from app.models.solution import solution_create
+
+
+def _content():
+    return '# Review me\n\n' + ('Detailed analysis. ' * MIN_CONTENT_LENGTH)
+
+
+def _pending_solution(db, sample_crackme, author='bob'):
+    solution = solution_create(
+        'Pending onsite writeup', author, sample_crackme, content=_content()
+    )
+    assert solution['visible'] is False
+    return solution
+
+
+def test_reviewer_routes_require_separate_reviewer_login(client, db):
+    response = client.get('/review/dashboard')
+
+    assert response.status_code == 302
+    assert response.location == '/review/login'
+
+
+def test_reviewer_login_requires_csrf(client, reviewer_account):
+    response = client.post('/review/login', data={
+        'username': 'reviewer',
+        'password': 'reviewer-password',
+    })
+
+    assert response.status_code == 403
+
+
+def test_reviewer_can_log_in_with_valid_credentials(client, reviewer_account):
+    with client.session_transaction() as session:
+        session['_reviewer_csrf_token'] = 'login-csrf'
+
+    response = client.post('/review/login', data={
+        'csrf_token': 'login-csrf',
+        'username': 'reviewer',
+        'password': 'reviewer-password',
+    })
+
+    assert response.status_code == 302
+    assert response.location == '/review/dashboard'
+    with client.session_transaction() as session:
+        assert session['_reviewer_user'] == 'reviewer'
+        assert session['_reviewer_is_admin'] is False
+
+
+def test_pending_markdown_writeup_appears_in_review_queue(
+        reviewer_client, db, sample_crackme, bob):
+    solution = _pending_solution(db, sample_crackme)
+
+    dashboard = reviewer_client.get('/review/dashboard')
+    queue = reviewer_client.get('/review/reviewsolution')
+    detail = reviewer_client.get(
+        f"/review/viewsolution?solution_uuid={solution['hexid']}"
+    )
+
+    assert dashboard.status_code == 200
+    assert b'Review solutions' in dashboard.data
+    assert b'<h2 class="text-center"> 1 </h2>' in dashboard.data
+    assert queue.status_code == 200
+    assert solution['hexid'].encode() in queue.data
+    assert b'Test Crackme' in queue.data
+    assert detail.status_code == 200
+    assert b'Pending onsite writeup' in detail.data
+    assert json.dumps(_content()).encode() in detail.data
+    assert b'Download attachment' not in detail.data
+
+
+def test_approval_requires_valid_reviewer_csrf(
+        reviewer_client, db, sample_crackme, bob):
+    solution = _pending_solution(db, sample_crackme)
+
+    response = reviewer_client.post('/review/approvesolution', data={
+        'uuid': solution['hexid'],
+        'csrf_token': 'wrong-token',
+    })
+
+    assert response.status_code == 403
+    assert db.solution.find_one({'hexid': solution['hexid']})['visible'] is False
+
+
+def test_reviewer_can_approve_markdown_only_writeup(
+        reviewer_client, client, db, sample_crackme, bob, monkeypatch):
+    from review import routes
+
+    solution = _pending_solution(db, sample_crackme)
+    monkeypatch.setattr(routes, 'log_reviewer_operation', lambda *args, **kwargs: None)
+    monkeypatch.setattr(routes, 'notify_solution_approved', lambda *args: None)
+
+    response = reviewer_client.post('/review/approvesolution', data={
+        'uuid': solution['hexid'],
+        'csrf_token': 'test-csrf-token',
+    })
+
+    assert response.status_code == 302
+    approved = db.solution.find_one({'hexid': solution['hexid']})
+    assert approved['visible'] is True
+    assert db.crackme.find_one({'_id': sample_crackme['_id']})['nbsolutions'] == 1
+    assert db.notifications.count_documents({'user': 'bob'}) == 1
+    assert db.notifications.count_documents({'user': 'alice'}) == 1
+    assert client.get(f"/solution/{solution['hexid']}").status_code == 200
+    assert client.get(f"/solution/{solution['hexid']}/content").status_code == 200
+
+
+def test_reviewer_can_reject_writeup_with_reason(
+        reviewer_client, db, sample_crackme, bob, monkeypatch):
+    from review import routes
+
+    solution = _pending_solution(db, sample_crackme)
+    monkeypatch.setattr(routes, 'log_reviewer_operation', lambda *args, **kwargs: None)
+
+    response = reviewer_client.post('/review/rejectsolution', data={
+        'uuid': solution['hexid'],
+        'reject_reason': '<b>Needs more explanation</b>',
+        'csrf_token': 'test-csrf-token',
+    })
+
+    assert response.status_code == 302
+    assert db.solution.find_one({'hexid': solution['hexid']}) is None
+    notification = db.notifications.find_one({'user': 'bob'})
+    assert 'Needs more explanation' in notification['text']
+    assert '<b>' not in notification['text']
+    assert '&lt;b&gt;' in notification['text']
+
+
+def test_approved_writeup_is_removed_from_pending_queue(
+        reviewer_client, db, sample_crackme, bob, monkeypatch):
+    from review import routes
+
+    solution = _pending_solution(db, sample_crackme)
+    monkeypatch.setattr(routes, 'log_reviewer_operation', lambda *args, **kwargs: None)
+    monkeypatch.setattr(routes, 'notify_solution_approved', lambda *args: None)
+    reviewer_client.post('/review/approvesolution', data={
+        'uuid': solution['hexid'],
+        'csrf_token': 'test-csrf-token',
+    })
+
+    queue = reviewer_client.get('/review/reviewsolution')
+
+    assert solution['hexid'].encode() not in queue.data

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,161 +1,92 @@
-"""
-Unit tests for Flask routes.
-"""
-import pytest
-from unittest.mock import patch, MagicMock
+"""Route integration tests using Flask's test client (no browser required)."""
+
+from app.services.passhash import match_string
 
 
-class TestPublicRoutes:
-    """Tests for public routes that don't require authentication."""
-
-    def test_index_page(self, client):
-        """Test the index page loads."""
-        with patch('app.models.user.count_users', return_value=100):
-            with patch('app.models.crackme.count_crackmes', return_value=500):
-                with patch('app.models.solution.count_solutions', return_value=200):
-                    response = client.get('/')
-                    assert response.status_code == 200
-
-    def test_faq_page(self, client):
-        """Test the FAQ page loads."""
-        response = client.get('/faq')
-        assert response.status_code == 200
-        assert b'FAQ' in response.data or b'Frequently Asked Questions' in response.data
-
-    def test_crackme_rules_page(self, client):
-        """Test the crackme rules page loads."""
-        response = client.get('/upload/crackmerules')
-        assert response.status_code == 200
-        assert b'Crackme' in response.data
-
-    def test_writeup_rules_page(self, client):
-        """Test the writeup rules page loads."""
-        response = client.get('/upload/writeuprules')
-        assert response.status_code == 200
-        assert b'Writeup' in response.data or b'Rules' in response.data
-
-    def test_login_page(self, client):
-        """Test the login page loads."""
-        response = client.get('/login')
-        assert response.status_code == 200
-        assert b'Login' in response.data or b'login' in response.data
-
-    def test_register_page(self, client):
-        """Test the register page loads."""
-        response = client.get('/register')
-        assert response.status_code == 200
-        assert b'Register' in response.data or b'register' in response.data
-
-    def test_search_page(self, client):
-        """Test the search page loads."""
-        response = client.get('/search')
-        assert response.status_code == 200
-        assert b'Search' in response.data or b'search' in response.data
-
-    def test_lasts_page(self, client):
-        """Test the latest crackmes page loads."""
-        with patch('app.models.crackme.get_last_crackmes', return_value=[]):
-            response = client.get('/lasts/1')
-            assert response.status_code == 200
-
-    def test_404_page(self, client):
-        """Test 404 page for non-existent routes."""
-        response = client.get('/nonexistent-page-12345')
-        assert response.status_code == 404
+def test_public_pages_load(client):
+    for path in ('/', '/faq', '/upload/crackmerules', '/upload/writeuprules',
+                 '/login', '/register', '/search', '/lasts/1'):
+        assert client.get(path).status_code == 200, path
 
 
-class TestAuthRoutes:
-    """Tests for authentication routes."""
-
-    def test_login_post_empty_fields(self, client):
-        """Test login with empty fields."""
-        response = client.post('/login', data={
-            'name': '',
-            'password': ''
-        })
-        # Should either redirect or show error
-        assert response.status_code in [200, 302, 400]
-
-    def test_login_post_invalid_user(self, client):
-        """Test login with invalid user."""
-        with patch('app.models.user.user_by_name', return_value=None):
-            response = client.post('/login', data={
-                'name': 'nonexistent',
-                'password': 'password123'
-            })
-            assert response.status_code in [200, 302]
-
-    def test_register_post_empty_fields(self, client):
-        """Test register with empty fields."""
-        response = client.post('/register', data={
-            'name': '',
-            'email': '',
-            'password': '',
-            'password_verify': ''
-        })
-        assert response.status_code in [200, 302, 400]
-
-    def test_register_post_password_mismatch(self, client):
-        """Test register with mismatched passwords."""
-        response = client.post('/register', data={
-            'name': 'testuser',
-            'email': 'test@example.com',
-            'password': 'password123',
-            'password_verify': 'different'
-        })
-        assert response.status_code in [200, 302]
-
-    def test_logout_redirects(self, client):
-        """Test logout redirects to index."""
-        response = client.get('/logout')
-        assert response.status_code in [302, 303]
+def test_unknown_route_is_404(client):
+    assert client.get('/not-a-real-route').status_code == 404
 
 
-class TestProtectedRoutes:
-    """Tests for routes that require authentication."""
-
-    def test_upload_crackme_requires_auth(self, client):
-        """Test that upload crackme page requires authentication."""
-        response = client.get('/upload/crackme')
-        # Should redirect to login
-        assert response.status_code in [302, 303, 401]
-
-    def test_notifications_requires_auth(self, client):
-        """Test that notifications page requires authentication."""
-        response = client.get('/notifications')
-        # Should redirect to login
-        assert response.status_code in [302, 303, 401]
-
-    def test_change_password_requires_auth(self, client):
-        """Test that change password page requires authentication."""
-        response = client.get('/change-password')
-        # Should redirect to login
-        assert response.status_code in [302, 303, 401]
+def test_anonymous_user_is_redirected_from_protected_pages(client):
+    for path in ('/upload/crackme', '/notifications', '/change-password'):
+        response = client.get(path)
+        assert response.status_code == 302, path
+        assert response.location == '/', path
 
 
-class TestCrackmeRoutes:
-    """Tests for crackme-related routes."""
-
-    def test_view_crackme_not_found(self, client):
-        """Test viewing a non-existent crackme."""
-        with patch('app.models.crackme.crackme_by_hexid', return_value=None):
-            response = client.get('/crackme/507f1f77bcf86cd799439011')
-            assert response.status_code == 404
-
-    def test_view_crackme_invalid_id(self, client):
-        """Test viewing a crackme with invalid ID."""
-        response = client.get('/crackme/invalid-id')
-        assert response.status_code in [400, 404]
+def test_authenticated_user_can_open_protected_pages(alice_client):
+    assert alice_client.get('/upload/crackme').status_code == 200
+    assert alice_client.get('/notifications').status_code == 200
+    assert alice_client.get('/change-password').status_code == 200
 
 
-class TestUserRoutes:
-    """Tests for user profile routes."""
+def test_login_with_valid_synthetic_user(client, alice):
+    response = client.post('/login', data={
+        'name': 'alice',
+        'password': 'alice-password',
+    })
 
-    def test_view_user_not_found(self, client):
-        """Test viewing a non-existent user profile."""
-        with patch('app.models.user.user_by_name', return_value=None):
-            with patch('app.models.crackme.get_crackmes_by_author', return_value=[]):
-                with patch('app.models.solution.get_solutions_by_author', return_value=[]):
-                    with patch('app.models.comment.get_comments_by_author', return_value=[]):
-                        response = client.get('/user/nonexistent')
-                        assert response.status_code in [200, 404]
+    assert response.status_code == 302
+    assert response.location == '/'
+    with client.session_transaction() as session:
+        assert session['name'] == 'alice'
+        assert session['email'] == 'alice@example.test'
+
+
+def test_login_with_wrong_password_does_not_authenticate(client, alice):
+    response = client.post('/login', data={
+        'name': 'alice',
+        'password': 'wrong-password',
+    })
+
+    assert response.status_code == 200
+    assert b'Password is incorrect' in response.data
+    with client.session_transaction() as session:
+        assert 'name' not in session
+        assert session['login_attempt'] == 1
+
+
+def test_registration_creates_a_user(client, db):
+    response = client.post('/register', data={
+        'name': 'charlie',
+        'email': 'CHARLIE@example.test',
+        'password': 'charlie-password',
+    })
+
+    assert response.status_code == 302
+    assert response.location == '/login'
+    user = db.user.find_one({'name': 'charlie'})
+    assert user['email'] == 'charlie@example.test'
+    assert match_string(user['password'], 'charlie-password') is True
+
+
+def test_logout_clears_only_main_auth(alice_client):
+    with alice_client.session_transaction() as session:
+        session['unrelated'] = 'preserved'
+
+    response = alice_client.get('/logout')
+    assert response.status_code == 302
+    assert response.location == '/'
+    with alice_client.session_transaction() as session:
+        assert 'name' not in session
+        assert 'email' not in session
+        assert session['unrelated'] == 'preserved'
+
+
+def test_missing_crackme_is_404(client):
+    from bson import ObjectId
+    assert client.get(f'/crackme/{ObjectId()}').status_code == 404
+
+
+def test_existing_user_profile_loads(client, alice):
+    assert client.get('/user/alice').status_code == 200
+
+
+def test_missing_user_profile_is_404(client):
+    assert client.get('/user/missing').status_code == 404

--- a/tests/test_rss_and_errors.py
+++ b/tests/test_rss_and_errors.py
@@ -1,0 +1,42 @@
+"""Tests for RSS output and graceful error paths."""
+
+from unittest.mock import patch
+
+
+def test_rss_feed_escapes_user_content(client, db, sample_crackme):
+    db.crackme.update_one({'_id': sample_crackme['_id']}, {'$set': {
+        'name': 'A & B <challenge>',
+        'info': '<script>alert(1)</script>',
+    }})
+    db.rating_difficulty.insert_one({
+        'crackmehexid': sample_crackme['hexid'], 'rating': 5,
+    })
+
+    response = client.get('/rss/crackme')
+
+    assert response.status_code == 200
+    assert response.mimetype == 'application/rss+xml'
+    assert b'A &amp; B &lt;challenge&gt;' in response.data
+    assert b'Very Hard' in response.data
+    assert b'&lt;script&gt;alert(1)&lt;/script&gt;' in response.data
+    assert b'http://localhost/crackme/' in response.data
+
+
+def test_rss_database_failure_returns_500(client):
+    with patch('app.controllers.rss.last_crackmes', side_effect=RuntimeError):
+        response = client.get('/rss/crackme')
+
+    assert response.status_code == 500
+    assert response.data == b'Error generating RSS feed'
+
+
+def test_index_degrades_to_zero_counts_on_database_error(client):
+    with patch('app.controllers.index.count_users', side_effect=RuntimeError):
+        response = client.get('/')
+
+    assert response.status_code == 200
+
+
+def test_static_and_well_known_missing_files_are_404(client):
+    assert client.get('/static/does-not-exist.txt').status_code == 404
+    assert client.get('/.well-known/does-not-exist.txt').status_code == 404

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,68 @@
+"""Route-level coverage for search filtering, sorting, and input fallback."""
+
+
+def _another_crackme(db, sample_crackme):
+    item = dict(sample_crackme)
+    item.pop('_id')
+    item.update({
+        'hexid': '507f1f77bcf86cd799439011',
+        'name': 'Windows Puzzle',
+        'author': 'bob',
+        'lang': 'Python',
+        'arch': 'ARM',
+        'platform': 'Windows',
+        'difficulty': 5.0,
+        'quality': 3.0,
+        'size': 2 * 1024 * 1024,
+    })
+    db.crackme.insert_one(item)
+    return item
+
+
+def test_search_filters_by_name_and_platform(client, db, sample_crackme):
+    _another_crackme(db, sample_crackme)
+
+    response = client.post('/search', data={
+        'name': 'Windows',
+        'platform': 'Windows',
+        'difficulty-min': '1', 'difficulty-max': '6',
+        'quality-min': '1', 'quality-max': '6',
+    })
+
+    assert response.status_code == 200
+    assert b'Windows Puzzle' in response.data
+    assert b'Test Crackme' not in response.data
+
+
+def test_search_applies_size_units_and_sorting(client, db, sample_crackme):
+    _another_crackme(db, sample_crackme)
+
+    response = client.post('/search', data={
+        'difficulty-min': '1', 'difficulty-max': '6',
+        'quality-min': '1', 'quality-max': '6',
+        'size-min': '1', 'size-min-unit': 'MB',
+        'sort_by': 'size', 'sort_order': 'desc',
+    })
+
+    assert response.status_code == 200
+    assert b'Windows Puzzle' in response.data
+    assert b'Test Crackme' not in response.data
+
+
+def test_search_invalid_numeric_and_sort_inputs_fall_back_safely(
+        client, sample_crackme):
+    response = client.post('/search', data={
+        'difficulty-min': 'invalid', 'difficulty-max': 'invalid',
+        'quality-min': 'invalid', 'quality-max': 'invalid',
+        'downloads-min': '-20', 'page': '-4',
+        'sort_by': 'drop-table', 'sort_order': 'sideways',
+    })
+
+    assert response.status_code == 200
+    assert b'Test Crackme' in response.data
+
+def test_random_route_returns_visible_crackmes(client, sample_crackme):
+    response = client.get('/random?sort_by=difficulty&sort_order=asc')
+
+    assert response.status_code == 200
+    assert b'Test Crackme' in response.data

--- a/tests/test_services_and_failures.py
+++ b/tests/test_services_and_failures.py
@@ -1,0 +1,150 @@
+"""Service integration boundaries and injected controller failure paths."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_discord_configuration_and_webhook_delivery(app):
+    from app.services import discord
+
+    config = {
+        'Enabled': True,
+        'WebhookPublic': 'https://discord.test/public',
+        'WebhookPrivate': 'https://discord.test/private',
+        'WebhookModeration': 'https://discord.test/moderation',
+    }
+    discord.init_discord(app, config)
+    assert discord.get_public_webhook().endswith('/public')
+    assert discord.get_private_webhook().endswith('/private')
+    assert discord.get_moderation_webhook().endswith('/moderation')
+    with patch.object(
+        discord.requests, 'post', return_value=MagicMock(status_code=204)
+    ) as post:
+        assert discord.send_to_webhook('https://discord.test/hook', message='hello') is True
+        assert post.call_args.kwargs['json']['content'] == 'hello'
+    with patch.object(discord.requests, 'post', side_effect=TimeoutError):
+        assert discord.send_to_webhook('https://discord.test/hook', message='hello') is False
+    assert discord.send_to_webhook('', message='hello') is False
+    discord.init_discord(app, {'Enabled': False})
+
+
+def test_discord_notification_payload_builders(app):
+    from app.services import discord
+
+    discord.init_discord(app, {'Enabled': True, 'WebhookModeration': 'hook'})
+    with patch.object(discord, 'send_moderation_notification', return_value=True) as send:
+        assert discord.notify_new_comment(
+            'alice', 'Challenge', 'abc', 'x' * 600,
+            comment_id='comment', spoiler_token='token',
+        ) is True
+        embed = send.call_args.args[0]
+        assert embed['fields'][2]['value'].endswith('...')
+        assert any(field['name'] == 'Actions' for field in embed['fields'])
+        discord.notify_spoiler_toggle('alice', 'Challenge', 'abc', 'bob', True)
+        assert 'Marked As Spoiler' in send.call_args.args[0]['title']
+        discord.notify_password_reset_request('alice@example.test')
+        assert send.call_args.args[0]['title'] == 'Password Reset Requested'
+        discord.notify_password_reset_complete('alice', 'alice@example.test')
+        assert send.call_args.args[0]['title'] == 'Password Reset Completed'
+    discord.init_discord(app, {'Enabled': False})
+
+
+def test_pending_discord_notifications_use_private_channel(app):
+    from app.services import discord
+
+    discord.init_discord(app, {'Enabled': True})
+    with patch.object(discord, 'send_private_notification', return_value=True) as send:
+        assert discord.notify_new_crackme('alice', 'Challenge') is True
+        assert send.call_args.kwargs['embed']['title'] == 'Pending Crackme Submission'
+        assert discord.notify_new_solution('bob', 'Challenge') is True
+        assert send.call_args.kwargs['embed']['title'] == 'Pending Solution Submission'
+    discord.init_discord(app, {'Enabled': False})
+
+
+@pytest.mark.parametrize('error,expected', [
+    (None, None),
+    (RuntimeError('no documents'), 'ErrNoResult'),
+    (RuntimeError('not found'), 'ErrNoResult'),
+    (RuntimeError('other'), 'RuntimeError'),
+])
+def test_standardize_database_errors(error, expected):
+    from app.models.errors import standardize_error
+    result = standardize_error(error)
+    assert (type(result).__name__ if result is not None else None) == expected
+
+
+def test_password_hash_matching_rejects_malformed_hashes():
+    from app.services.passhash import match_bytes, match_string
+    assert match_string('not-a-hash', 'password') is False
+    assert match_string(None, 'password') is False
+    assert match_bytes(b'not-a-hash', b'password') is False
+    assert match_bytes(None, b'password') is False
+
+
+def test_notification_controller_database_failures(alice_client, alice):
+    with patch(
+        'app.controllers.notifications.notifications_by_user', side_effect=RuntimeError
+    ):
+        page = alice_client.get('/notifications')
+    with patch(
+        'app.controllers.notifications.notification_mark_seen_single',
+        side_effect=RuntimeError,
+    ):
+        seen = alice_client.post('/notifications/mark-seen', data={'hexid': 'x'})
+    with patch(
+        'app.controllers.notifications.notification_remove', side_effect=RuntimeError
+    ):
+        deleted = alice_client.post('/notifications/delete', data={'hexid': 'x'})
+    assert page.status_code == 200
+    assert seen.status_code == deleted.status_code == 500
+
+
+def test_password_change_hash_and_update_failures(alice_client, alice):
+    payload = {
+        'current_password': 'alice-password',
+        'new_password': 'replacement-password',
+        'new_password_verify': 'replacement-password',
+    }
+    with patch('app.controllers.password.hash_string', side_effect=RuntimeError):
+        hashing = alice_client.post('/change-password', data=payload)
+    with patch('app.controllers.password.update_user_password', side_effect=RuntimeError):
+        updating = alice_client.post('/change-password', data=payload)
+    assert hashing.status_code == 500
+    assert updating.status_code == 500
+
+
+def test_rating_missing_fields_and_database_failure(alice_client, sample_crackme):
+    diff_path = f"/crackme/rate-diff/{sample_crackme['hexid']}"
+    qual_path = f"/crackme/rate-qual/{sample_crackme['hexid']}"
+    assert alice_client.post(diff_path, data={}).status_code == 302
+    assert alice_client.post(qual_path, data={}).status_code == 302
+    with patch(
+        'app.controllers.rating.is_already_rated_difficulty', side_effect=RuntimeError
+    ):
+        assert alice_client.post(diff_path, data={'difficulty': '3'}).status_code == 500
+    with patch(
+        'app.controllers.rating.is_already_rated_quality', side_effect=RuntimeError
+    ):
+        assert alice_client.post(qual_path, data={'quality': '3'}).status_code == 500
+
+
+def test_search_show_all_and_database_failure(client):
+    with patch('app.controllers.search.search_crackme', return_value=([], False)) as search:
+        response = client.post('/search', data={
+            'show_all': '1', 'size-min': '2', 'size-min-unit': 'GB',
+            'size-max': '3', 'size-max-unit': 'KB',
+        })
+    assert response.status_code == 200
+    assert search.call_args.kwargs['per_page'] == 10000
+    assert search.call_args.kwargs['size_min'] == 2 * 1024**3
+    assert search.call_args.kwargs['size_max'] == 3 * 1024
+    with patch('app.controllers.search.search_crackme', side_effect=RuntimeError):
+        assert client.post('/search', data={}).status_code == 200
+
+
+def test_random_search_database_unavailable(client):
+    from app.models.errors import ErrUnavailable
+    with patch('app.controllers.search.random_crackmes', side_effect=ErrUnavailable):
+        response = client.get('/random')
+    assert response.status_code == 200

--- a/tests/test_services_extended.py
+++ b/tests/test_services_extended.py
@@ -1,0 +1,147 @@
+"""Focused unit coverage for deterministic service boundaries and helpers."""
+
+import io
+import struct
+import tarfile
+import zipfile
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from app.services import archive, email
+
+
+def _zip(files):
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, 'w') as zipped:
+        for name, data in files.items():
+            zipped.writestr(name, data)
+    return output.getvalue()
+
+
+def test_archive_counts_real_files_but_ignores_metadata():
+    data = _zip({
+        'one.bin': b'1',
+        'two.txt': b'2',
+        '__MACOSX/._one.bin': b'metadata',
+        '.DS_Store': b'metadata',
+    })
+
+    assert archive.get_archive_file_count(data) == 2
+    assert archive.is_single_file_archive(data) is False
+    assert archive.get_archive_file_count(b'not a zip') is None
+
+
+def test_single_file_zip_is_detected():
+    assert archive.is_single_file_archive(_zip({'only.bin': b'data'})) is True
+
+
+def test_rar_and_tar_are_rejected_but_plain_data_is_allowed():
+    tar_buffer = io.BytesIO()
+    with tarfile.open(fileobj=tar_buffer, mode='w') as tar:
+        payload = b'content'
+        info = tarfile.TarInfo('file.txt')
+        info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+
+    assert archive.is_unsupported_archive(b'Rar!payload') is True
+    assert archive.is_unsupported_archive(tar_buffer.getvalue()) is True
+    assert archive.is_unsupported_archive(b'plain binary') is False
+
+
+def test_pe_detection_uses_extension_and_header_signature():
+    header = bytearray(128)
+    header[:2] = b'MZ'
+    header[0x3C:0x40] = struct.pack('<I', 64)
+    header[64:68] = b'PE\x00\x00'
+
+    assert archive.is_pe_file('program.EXE', b'short') is True
+    assert archive.is_pe_file('program.bin', bytes(header)) is True
+    assert archive.is_pe_file('program.bin', b'MZ' + b'0' * 20) is False
+
+
+def test_zip_encryption_flag_is_detected(monkeypatch):
+    info = type('Info', (), {'flag_bits': 1})()
+    fake_zip = type('FakeZip', (), {
+        '__enter__': lambda self: self,
+        '__exit__': lambda self, *args: None,
+        'infolist': lambda self: [info],
+    })()
+    monkeypatch.setattr(archive.zipfile, 'ZipFile', lambda *a, **k: fake_zip)
+
+    assert archive.is_archive_password_protected(b'data') is True
+
+
+def test_email_configuration_and_plain_text_send(monkeypatch):
+    send = monkeypatch.setattr(email.resend.Emails, 'send', lambda params: params)
+    email.configure({'ApiKey': 'test-key', 'From': 'sender@example.test'})
+
+    with patch.object(email.resend.Emails, 'send') as resend_send:
+        assert email.send_email('user@example.test', 'Subject', 'Body') is True
+        params = resend_send.call_args.args[0]
+        assert params['from'] == 'sender@example.test'
+        assert params['to'] == ['user@example.test']
+        assert params['text'] == 'Body'
+
+
+def test_html_email_and_email_failures():
+    email.configure({'ApiKey': 'test-key'})
+    with patch.object(email.resend.Emails, 'send') as send:
+        assert email.send_html_email(
+            'user@example.test', 'Subject', '<b>Body</b>', 'Body'
+        ) is True
+        assert send.call_args.args[0]['html'] == '<b>Body</b>'
+        assert send.call_args.args[0]['text'] == 'Body'
+
+    with patch.object(email.resend.Emails, 'send', side_effect=RuntimeError):
+        assert email.send_email('user@example.test', 'Subject', 'Body') is False
+        assert email.send_html_email('user@example.test', 'Subject', '<b>x</b>') is False
+
+    email.configure({})
+    assert email.send_email('user@example.test', 'Subject', 'Body') is False
+    assert email.send_html_email('user@example.test', 'Subject', '<b>x</b>') is False
+
+
+def test_template_filters_cover_dates_sizes_mentions_and_invalid_values(app):
+    filters = app.jinja_env.filters
+    globals_ = app.jinja_env.globals
+    now = datetime(2026, 1, 2, 3, 4)
+
+    assert filters['PRETTYTIME'](now) == '2026-01-02 03:04'
+    assert filters['PRETTYTIME']('not-a-date') == 'not-a-date'
+    assert filters['PRETTYTIMEFORMAT'](now, '%Y') == '2026'
+    assert filters['FILESIZE'](0) == '-'
+    assert filters['FILESIZE'](2048) == '2.00 KB'
+    assert filters['FILESIZE'](2**21) == '2.00 MB'
+    assert filters['FILESIZE'](2**31) == '2.00 GB'
+    rendered = str(filters['render_mentions']('<script> @alice'))
+    assert '&lt;script&gt;' in rendered
+    assert '<a href="/user/alice">@alice</a>' in rendered
+    assert globals_['TIMECOMPARE'](now, now + timedelta(seconds=10), 5) is True
+    assert globals_['DIFFERENT_DATE'](now, now + timedelta(days=1)) is True
+
+
+def test_session_helpers_preserve_unrelated_state(app):
+    from app.services.session import clear_session, get_session, get_username, is_authenticated
+
+    with app.test_request_context('/'):
+        session = get_session()
+        session.update(name='alice', email='alice@example.test', unrelated='keep')
+        assert get_username() == 'alice'
+        assert is_authenticated() is True
+        clear_session()
+        assert is_authenticated() is False
+        assert session['unrelated'] == 'keep'
+
+
+def test_repopulate_and_flash_helper(app):
+    from flask import get_flashed_messages
+    from app.services.view import add_flash, repopulate
+
+    context = {}
+    repopulate(['name', 'email'], {'name': 'alice'}, context)
+    assert context == {'name': 'alice', 'email': ''}
+    with app.test_request_context('/'):
+        add_flash('Saved', 'success')
+        assert get_flashed_messages(with_categories=True) == [('success', 'Saved')]

--- a/tests/test_user_workflows.py
+++ b/tests/test_user_workflows.py
@@ -1,0 +1,123 @@
+"""Integration tests for important authenticated user workflows."""
+
+from app.models.notification import notification_add
+from app.services.passhash import match_string
+
+
+def test_user_can_change_password(alice_client, db, alice):
+    response = alice_client.post('/change-password', data={
+        'current_password': 'alice-password',
+        'new_password': 'new-secure-password',
+        'new_password_verify': 'new-secure-password',
+    })
+
+    assert response.status_code == 200
+    assert response.data == b'Password has been successfully updated'
+    updated = db.user.find_one({'name': 'alice'})
+    assert match_string(updated['password'], 'new-secure-password') is True
+    assert match_string(updated['password'], 'alice-password') is False
+
+
+def test_password_change_rejects_wrong_current_password(alice_client, db, alice):
+    original_hash = db.user.find_one({'name': 'alice'})['password']
+
+    response = alice_client.post('/change-password', data={
+        'current_password': 'incorrect',
+        'new_password': 'new-secure-password',
+        'new_password_verify': 'new-secure-password',
+    })
+
+    assert response.status_code == 401
+    assert response.data == b'Current password is incorrect'
+    assert db.user.find_one({'name': 'alice'})['password'] == original_hash
+
+
+def test_password_change_validates_confirmation_and_length(alice_client, alice):
+    mismatch = alice_client.post('/change-password', data={
+        'current_password': 'alice-password',
+        'new_password': 'first-password',
+        'new_password_verify': 'second-password',
+    })
+    too_short = alice_client.post('/change-password', data={
+        'current_password': 'alice-password',
+        'new_password': 'short',
+        'new_password_verify': 'short',
+    })
+
+    assert mismatch.status_code == 400
+    assert mismatch.data == b'Passwords do not match'
+    assert too_short.status_code == 400
+    assert b'at least 8 characters' in too_short.data
+
+
+def test_difficulty_rating_is_created_then_updated(
+        alice_client, db, sample_crackme):
+    path = f"/crackme/rate-diff/{sample_crackme['hexid']}"
+
+    first = alice_client.post(path, data={'difficulty': '2'})
+    second = alice_client.post(path, data={'difficulty': '6'})
+
+    assert first.status_code == 302
+    assert second.status_code == 302
+    assert db.rating_difficulty.count_documents({}) == 1
+    assert db.rating_difficulty.find_one({})['rating'] == 6
+    assert db.crackme.find_one({'_id': sample_crackme['_id']})['difficulty'] == 6.0
+
+
+def test_multiple_quality_ratings_recalculate_average(
+        alice_client, bob_client, db, sample_crackme):
+    path = f"/crackme/rate-qual/{sample_crackme['hexid']}"
+
+    assert alice_client.post(path, data={'quality': '2'}).status_code == 302
+    assert bob_client.post(path, data={'quality': '6'}).status_code == 302
+
+    assert db.rating_quality.count_documents({}) == 2
+    assert db.crackme.find_one({'_id': sample_crackme['_id']})['quality'] == 4.0
+
+
+def test_invalid_rating_is_not_stored(alice_client, db, sample_crackme):
+    response = alice_client.post(
+        f"/crackme/rate-diff/{sample_crackme['hexid']}",
+        data={'difficulty': '7'},
+    )
+
+    assert response.status_code == 500
+    assert db.rating_difficulty.count_documents({}) == 0
+
+
+def test_marking_notification_seen_is_idempotent(alice_client, db, alice):
+    notification = notification_add('alice', 'A writeup was approved')
+    assert db.user.find_one({'name': 'alice'})['unread_notifications'] == 1
+
+    first = alice_client.post(
+        '/notifications/mark-seen', data={'hexid': notification['hexid']}
+    )
+    second = alice_client.post(
+        '/notifications/mark-seen', data={'hexid': notification['hexid']}
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert db.notifications.find_one({'hexid': notification['hexid']})['seen'] is True
+    assert db.user.find_one({'name': 'alice'})['unread_notifications'] == 0
+
+
+def test_user_cannot_modify_another_users_notification(
+        alice_client, db, alice, bob):
+    notification = notification_add('bob', 'Private notification')
+
+    assert alice_client.post(
+        '/notifications/mark-seen', data={'hexid': notification['hexid']}
+    ).status_code == 200
+    assert alice_client.post(
+        '/notifications/delete', data={'hexid': notification['hexid']}
+    ).status_code == 200
+
+    stored = db.notifications.find_one({'hexid': notification['hexid']})
+    assert stored is not None
+    assert stored['seen'] is False
+
+
+def test_notification_actions_require_an_identifier(alice_client, alice):
+    assert alice_client.post('/notifications/mark-seen', data={}).status_code == 400
+    assert alice_client.post('/notifications/delete', data={}).status_code == 400

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,115 +1,58 @@
-"""
-Unit tests for input validation functions.
-"""
+"""Unit tests for application input-validation helpers."""
+
 import pytest
+from werkzeug.datastructures import MultiDict
+
+from app.services.view import (
+    authorized_chars_only,
+    is_valid_hexid,
+    validate_required,
+)
 
 
-class TestUsernameValidation:
-    """Tests for username validation."""
-
-    def test_valid_username(self):
-        """Test valid usernames."""
-        valid_usernames = [
-            'user',
-            'user123',
-            'test_user',
-            'TestUser',
-            'a' * 20
-        ]
-        for username in valid_usernames:
-            # Username should be alphanumeric with underscores, 3-30 chars
-            assert len(username) >= 1
-            assert len(username) <= 30
-
-    def test_invalid_username_too_short(self):
-        """Test username that's too short."""
-        username = 'ab'
-        assert len(username) < 3
-
-    def test_invalid_username_too_long(self):
-        """Test username that's too long."""
-        username = 'a' * 31
-        assert len(username) > 30
+@pytest.mark.parametrize('value', [
+    'alice',
+    'Alice_123',
+    'user-name',
+    'user+tag@example.test',
+])
+def test_authorized_chars_accepts_supported_names_and_emails(value):
+    assert authorized_chars_only(value) is True
 
 
-class TestEmailValidation:
-    """Tests for email validation."""
-
-    def test_valid_email(self):
-        """Test valid email addresses."""
-        valid_emails = [
-            'test@example.com',
-            'user.name@domain.org',
-            'user+tag@example.co.uk'
-        ]
-        for email in valid_emails:
-            assert '@' in email
-            assert '.' in email.split('@')[1]
-
-    def test_invalid_email_no_at(self):
-        """Test email without @ symbol."""
-        email = 'testexample.com'
-        assert '@' not in email
-
-    def test_invalid_email_no_domain(self):
-        """Test email without domain."""
-        email = 'test@'
-        parts = email.split('@')
-        assert len(parts) < 2 or parts[1] == ''
+@pytest.mark.parametrize('value', [
+    'user name',
+    'user<script>',
+    'user/example',
+    'snowman☃',
+])
+def test_authorized_chars_rejects_unsupported_characters(value):
+    assert authorized_chars_only(value) is False
 
 
-class TestPasswordValidation:
-    """Tests for password validation."""
-
-    def test_valid_password(self):
-        """Test valid passwords."""
-        valid_passwords = [
-            'password123',
-            'SecureP@ss1',
-            'abcdefgh',
-            '12345678'
-        ]
-        for password in valid_passwords:
-            assert len(password) >= 8
-
-    def test_invalid_password_too_short(self):
-        """Test password that's too short."""
-        password = '1234567'
-        assert len(password) < 8
-
-    def test_password_whitespace(self):
-        """Test password with whitespace."""
-        password = 'pass word'
-        # Some systems allow spaces, others don't
-        assert len(password) >= 8
+@pytest.mark.parametrize('value', [
+    '507f1f77bcf86cd799439011',
+    'ABCDEF77BCF86CD799439011',
+])
+def test_valid_hexids(value):
+    assert is_valid_hexid(value) is True
 
 
-class TestCrackmeValidation:
-    """Tests for crackme input validation."""
+@pytest.mark.parametrize('value', [
+    '',
+    '507f1f77bcf86cd79943901',
+    '507f1f77bcf86cd7994390110',
+    '507f1f77bcf86cd79943901z',
+])
+def test_invalid_hexids(value):
+    assert is_valid_hexid(value) is False
 
-    def test_valid_crackme_name(self):
-        """Test valid crackme names."""
-        valid_names = [
-            'My Crackme',
-            'CrackMe_v1',
-            'Easy Challenge'
-        ]
-        for name in valid_names:
-            assert len(name) >= 1
-            assert len(name) <= 100
 
-    def test_valid_difficulty(self):
-        """Test valid difficulty ratings."""
-        valid_difficulties = [1, 2, 3, 4, 5, 6]
-        for diff in valid_difficulties:
-            assert 1 <= diff <= 6
+def test_required_fields_reports_the_first_missing_field():
+    form = MultiDict({'name': 'alice', 'email': ''})
+    assert validate_required(form, ['name', 'email', 'password']) == (False, 'email')
 
-    def test_invalid_difficulty_too_low(self):
-        """Test difficulty rating too low."""
-        difficulty = 0
-        assert difficulty < 1
 
-    def test_invalid_difficulty_too_high(self):
-        """Test difficulty rating too high."""
-        difficulty = 7
-        assert difficulty > 6
+def test_required_fields_accepts_complete_form():
+    form = MultiDict({'name': 'alice', 'email': 'alice@example.test'})
+    assert validate_required(form, ['name', 'email']) == (True, None)


### PR DESCRIPTION
## What changed

- add isolated Flask and MongoDB test fixtures with synthetic authenticated users
- cover onsite Markdown writeup submission, serving, attachment, and moderation workflows
- cover reviewer authentication, CSRF, approvals, rejections, administration, logging, deletion, and site archives
- expand route, model, service, validation, failure, rollback, and security coverage across the site
- add GitHub Actions jobs for every push and pull request using both mongomock and MongoDB 7
- enforce a 75% branch-coverage floor in CI
- make application configuration and MongoDB clients injectable for deterministic tests
- isolate reviewer authentication and CSRF helpers in `review/auth.py`

## Why

The previous tests were stale in several places, accepted ambiguous outcomes, and could not reliably exercise authenticated workflows without production users or configuration. Reviewer and onsite-writeup paths also lacked sufficient integration coverage.

These changes give CI disposable users and databases, exact behavioral assertions, real-MongoDB validation, and broad coverage of important success, authorization, validation, rollback, and failure paths without browser automation.

## Additional fix

The expanded tests found that a malformed `None` password hash raised `AttributeError`. Password matching now fails closed and returns `False` for that case.

## Validation

- `194 passed`
- approximately 82% statement coverage
- 78% branch coverage
- Python syntax compilation passes
- `git diff --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
