### PR TITLE
Add Python and AutoIt to the language dropdowns

### DIFF
--- a/review/templates/reviewer/editcrackme.html
+++ b/review/templates/reviewer/editcrackme.html
@@ -54,6 +54,8 @@
                             <option value="Go" {{ 'selected' if crackme.lang == 'Go' else '' }}>Go</option>
                             <option value="Rust" {{ 'selected' if crackme.lang == 'Rust' else '' }}>Rust</option>
                             <option value="WebAssembly" {{ 'selected' if crackme.lang == 'WebAssembly' else '' }}>WebAssembly</option>
+                            <option value="Python" {{ 'selected' if crackme.lang == 'Python' else '' }}>Python</option>
+                            <option value="AutoIt" {{ 'selected' if crackme.lang == 'AutoIt' else '' }}>AutoIt</option>
                             <option value="(Visual) Basic" {{ 'selected' if crackme.lang == '(Visual) Basic' else '' }}>(Visual) Basic</option>
                             <option value="Borland Delphi" {{ 'selected' if crackme.lang == 'Borland Delphi' else '' }}>Borland Delphi</option>
                             <option value="Turbo Pascal" {{ 'selected' if crackme.lang == 'Turbo Pascal' else '' }}>Turbo Pascal</option>

--- a/templates/crackme/create.html
+++ b/templates/crackme/create.html
@@ -60,6 +60,8 @@
                     <option value="Go">Go</option>
                     <option value="Rust">Rust</option>
                     <option value="WebAssembly">WebAssembly</option>
+                    <option value="Python">Python</option>
+                    <option value="AutoIt">AutoIt</option>
                     <option value="(Visual) Basic">(Visual) Basic</option>
                     <option value="Borland Delphi">Borland Delphi</option>
                     <option value="Turbo Pascal">Turbo Pascal</option>

--- a/templates/crackme/edit.html
+++ b/templates/crackme/edit.html
@@ -23,6 +23,8 @@
                     <option value="Go" {{ 'selected' if crackme.lang == 'Go' else '' }}>Go</option>
                     <option value="Rust" {{ 'selected' if crackme.lang == 'Rust' else '' }}>Rust</option>
                     <option value="WebAssembly" {{ 'selected' if crackme.lang == 'WebAssembly' else '' }}>WebAssembly</option>
+                    <option value="Python" {{ 'selected' if crackme.lang == 'Python' else '' }}>Python</option>
+                    <option value="AutoIt" {{ 'selected' if crackme.lang == 'AutoIt' else '' }}>AutoIt</option>
                     <option value="(Visual) Basic" {{ 'selected' if crackme.lang == '(Visual) Basic' else '' }}>(Visual) Basic</option>
                     <option value="Borland Delphi" {{ 'selected' if crackme.lang == 'Borland Delphi' else '' }}>Borland Delphi</option>
                     <option value="Turbo Pascal" {{ 'selected' if crackme.lang == 'Turbo Pascal' else '' }}>Turbo Pascal</option>

--- a/templates/search/search.html
+++ b/templates/search/search.html
@@ -121,6 +121,8 @@
                     <option value="Go" {{ 'selected' if 'Go' in search_params.get('lang', []) else '' }}>Go</option>
                     <option value="Rust" {{ 'selected' if 'Rust' in search_params.get('lang', []) else '' }}>Rust</option>
                     <option value="WebAssembly" {{ 'selected' if 'WebAssembly' in search_params.get('lang', []) else '' }}>WebAssembly</option>
+                    <option value="Python" {{ 'selected' if 'Python' in search_params.get('lang', []) else '' }}>Python</option>
+                    <option value="AutoIt" {{ 'selected' if 'AutoIt' in search_params.get('lang', []) else '' }}>AutoIt</option>
                     <option value="(Visual) Basic" {{ 'selected' if '(Visual) Basic' in search_params.get('lang', []) else '' }}>(Visual) Basic</option>
                     <option value="Borland Delphi" {{ 'selected' if 'Borland Delphi' in search_params.get('lang', []) else '' }}>Borland Delphi</option>
                     <option value="Turbo Pascal" {{ 'selected' if 'Turbo Pascal' in search_params.get('lang', []) else '' }}>Turbo Pascal</option>


### PR DESCRIPTION
## What
Adds **Python** and **AutoIt** as selectable languages in all four language `<select>` dropdowns:
- `templates/crackme/create.html`
- `templates/crackme/edit.html`
- `templates/search/search.html`
- `review/templates/reviewer/editcrackme.html`

## Why
- **Python** already exists as a `lang` value in the database (Python crackmes are live), but it was **missing from every dropdown** — so reviewers/authors couldn't select it, and it wasn't filterable in search. This fixes that gap.
- **AutoIt** is a new language: a Detect It Easy scan of the corpus surfaced AutoIt3-compiled crackmes that were all sitting under `Unspecified/other`. (A related DB relabel sets those rows to `AutoIt`.)

Both are inserted right after `WebAssembly`, matching each template's existing Jinja pattern (plain / `crackme.lang ==` / `in search_params.get('lang', [])`).

## Notes
- No server-side allowlist for `lang` exists in the Python code, so no backend change is needed — the field stores whatever the form submits.
- PureBasic crackmes found in the same scan were **merged into the existing `(Visual) Basic`** category, so no new option was needed for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)