### PR TITLE
Add additive migration to import DIE-detected packer tags

### DIFF
--- a/script/import_packer_tags.py
+++ b/script/import_packer_tags.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+Additively import the DIE-detected packer tags into the database.
+
+This is the SAFE, incremental counterpart to sync_tags.py. Where sync_tags.py is
+authoritative (it clears every crackme's tags and rewrites them from the dataset,
+which would wipe any tag edits made on the site since the initial import), this
+script only ADDS the packer tags to the specific crackmes that gained them, using
+$addToSet. It never removes a tag and never touches any other crackme, so manual
+edits made after the initial import are preserved.
+
+What it does:
+  Phase A (vocabulary): $addToSet the packer sub-labels into the existing
+    tag_vocabulary document (so new names like "PE-PACK" become selectable /
+    filterable). Non-destructive - only adds, existing entries untouched.
+  Phase B (crackme tags): for each affected crackme, $addToSet "Packer" plus its
+    specific packer name(s) into the crackme's tags array. Non-destructive.
+
+Reads packer_tags.json  ->  {hexid: [packer sub-label names]}  (empty list = the
+crackme is packed but with an unreliable/obscure packer, so only the generic
+"Packer" class is added).
+
+Usage:
+    cd /path/to/crackmesone_python/script
+    python import_packer_tags.py            # dry run (default)
+    python import_packer_tags.py --apply    # actually write
+
+After --apply, restart the app workers so they pick up the new vocabulary.
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from pymongo import MongoClient
+
+# Stable constants (kept local so this script needs only pymongo, not the full app).
+VOCAB_COLLECTION = "tag_vocabulary"
+VOCAB_ID = "current"
+PACKER_CLASS = "Packer"
+
+
+def main():
+    apply_changes = "--apply" in sys.argv
+    dry_run = not apply_changes
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    with open(os.path.join(os.path.dirname(here), "config", "config.json")) as f:
+        config = json.load(f)
+    with open(os.path.join(here, "packer_tags.json")) as f:
+        packer_tags = json.load(f)
+
+    mongo_url = config["Database"].get("URL", "mongodb://127.0.0.1:27017")
+    db_name = config["Database"].get("Name", "crackmesone")
+    client = MongoClient(mongo_url)
+    db = client[db_name]
+    crackme = db["crackme"]
+    vocab_col = db[VOCAB_COLLECTION]
+
+    print(f"Connected to MongoDB: {db_name}")
+    print(f"Loaded {len(packer_tags)} crackmes with packer findings")
+    if dry_run:
+        print("\n[DRY RUN - no changes written; re-run with --apply]\n")
+
+    # distinct sub-label names we may need in the vocabulary
+    sublabels = sorted({n for names in packer_tags.values() for n in names})
+
+    # ---- Phase A: vocabulary (additive) ----
+    print("== Phase A: vocabulary ==")
+    voc = vocab_col.find_one({"_id": VOCAB_ID})
+    if voc is None:
+        print("  WARNING: no tag_vocabulary document found. The site is on the built-in")
+        print("  default vocabulary. Establish a DB vocabulary first (e.g. sync_tags.py")
+        print("  --vocab-only --apply), then re-run this script. Skipping vocab phase.")
+    else:
+        have = set(voc.get("sublabels", {}).get(PACKER_CLASS, []))
+        missing = [s for s in sublabels if s not in have]
+        class_missing = PACKER_CLASS not in (voc.get("classes") or [])
+        print(f"  new packer sub-labels to add: {missing or 'none'}")
+        if class_missing:
+            print(f"  '{PACKER_CLASS}' class missing from vocabulary -> will add")
+        if not dry_run and (missing or class_missing):
+            update = {}
+            if missing:
+                update.setdefault("$addToSet", {})[f"sublabels.{PACKER_CLASS}"] = {"$each": missing}
+            if class_missing:
+                update.setdefault("$addToSet", {})["classes"] = PACKER_CLASS
+            vocab_col.update_one({"_id": VOCAB_ID}, update)
+            print("  vocabulary updated")
+
+    # ---- Phase B: crackme tags (additive, per hexid) ----
+    print("\n== Phase B: crackme tags ==")
+    would = already = not_found = 0
+    for hexid, names in packer_tags.items():
+        add = [PACKER_CLASS] + list(names)
+        doc = crackme.find_one({"hexid": hexid}, {"tags": 1})
+        if not doc:
+            not_found += 1
+            continue
+        current = set(doc.get("tags") or [])
+        new = [t for t in add if t not in current]
+        if not new:
+            already += 1
+            continue
+        would += 1
+        if not dry_run:
+            crackme.update_one({"hexid": hexid}, {"$addToSet": {"tags": {"$each": add}}})
+
+    print(f"  crackmes that {'would gain' if dry_run else 'gained'} packer tags: {would}")
+    print(f"  already had them (skipped): {already}")
+    print(f"  not found in database: {not_found}")
+
+    if dry_run:
+        print("\nThis was a dry run. Re-run with --apply to write.")
+    else:
+        print("\nDone. Restart the app workers to pick up the new vocabulary.")
+    client.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/script/packer_tags.json
+++ b/script/packer_tags.json
@@ -229,10 +229,7 @@
  "5ab77f5a33c5d40ad448c511": [
   "UPX"
  ],
- "5ab77f5a33c5d40ad448c521": [
-  "PE-PACK",
-  "UPX"
- ],
+ "5ab77f5a33c5d40ad448c521": [],
  "5ab77f5a33c5d40ad448c541": [
   "UPX"
  ],
@@ -413,10 +410,7 @@
  "5ab77f6233c5d40ad448c970": [
   "UPX"
  ],
- "5ab77f6233c5d40ad448c972": [
-  "ASPack",
-  "UPX"
- ],
+ "5ab77f6233c5d40ad448c972": [],
  "5ab77f6233c5d40ad448c973": [
   "ASPack"
  ],
@@ -573,11 +567,7 @@
  "5c0da25633c5d41e58e00557": [
   "UPX"
  ],
- "5d12784f33c5d41c6d56e1a6": [
-  "Babel .NET",
-  "ConfuserEx",
-  "Goliath"
- ],
+ "5d12784f33c5d41c6d56e1a6": [],
  "5f2eea5433c5d42a7c667c48": [
   "UPX"
  ],
@@ -587,15 +577,8 @@
  "5f7237e933c5d4357b3b033b": [
   "UPX"
  ],
- "5fd6173633c5d424269a1b81": [
-  "Confuser",
-  "Dotfuscator",
-  "Goliath"
- ],
- "5fe0bfef33c5d4264e590068": [
-  "Confuser",
-  "ConfuserEx"
- ],
+ "5fd6173633c5d424269a1b81": [],
+ "5fe0bfef33c5d4264e590068": [],
  "5fe5ed8633c5d4264e5900d9": [
   "UPX"
  ],
@@ -603,39 +586,20 @@
  "60be2a6033c5d410b8842c91": [
   "UPX"
  ],
- "6139ecce33c5d4649c52b980": [
-  "Babel .NET",
-  "Dotfuscator",
-  "Goliath",
-  "Yano"
- ],
+ "6139ecce33c5d4649c52b980": [],
  "619a59ba33c5d455dece61e3": [
   "SmartAssembly"
  ],
  "61d6581033c5d413767ca32f": [
   "SmartAssembly"
  ],
- "623f6cd033c5d46c8bcc055d": [
-  "Babel .NET",
-  "Yano"
- ],
- "6260362133c5d42a191a5d2e": [
-  "Babel .NET",
-  "Confuser",
-  "Goliath",
-  "Yano"
- ],
+ "623f6cd033c5d46c8bcc055d": [],
+ "6260362133c5d42a191a5d2e": [],
  "62bb2f0933c5d4251e723a46": [
   "PyInstaller"
  ],
  "62cd5ccc33c5d44a934e9750": [],
- "631b0da633c5d4425e2cd2a3": [
-  "Babel .NET",
-  "Confuser",
-  "Goliath",
-  "Sixxpack",
-  "Yano"
- ],
+ "631b0da633c5d4425e2cd2a3": [],
  "64216f6833c5d447bc761e17": [
   "UPX"
  ],
@@ -655,10 +619,7 @@
  "664a153e6b8bd8ddfe33cc66": [
   "UPX"
  ],
- "665bcbdbe7b35c09bb2666a4": [
-  "Confuser",
-  "ConfuserEx"
- ],
+ "665bcbdbe7b35c09bb2666a4": [],
  "6675db88e7b35c09bb26703c": [
   "Confuser"
  ],
@@ -671,13 +632,7 @@
  "66ce5d65b899a3b9dd02b12e": [
   "UPX"
  ],
- "670e2b1f9b533b4c22bd1441": [
-  "Babel .NET",
-  "Confuser",
-  "Goliath",
-  "Sixxpack",
-  "Yano"
- ],
+ "670e2b1f9b533b4c22bd1441": [],
  "673ff5da9b533b4c22bd2fff": [
   "UPX"
  ],

--- a/script/packer_tags.json
+++ b/script/packer_tags.json
@@ -1,0 +1,703 @@
+{
+ "5ab77f5333c5d40ad448c107": [],
+ "5ab77f5333c5d40ad448c112": [
+  "FSG"
+ ],
+ "5ab77f5333c5d40ad448c113": [
+  "ARM Protector"
+ ],
+ "5ab77f5333c5d40ad448c123": [
+  "BJFnt"
+ ],
+ "5ab77f5433c5d40ad448c145": [
+  "FSG"
+ ],
+ "5ab77f5433c5d40ad448c165": [
+  "FSG"
+ ],
+ "5ab77f5433c5d40ad448c166": [
+  "FSG"
+ ],
+ "5ab77f5433c5d40ad448c167": [
+  "FSG"
+ ],
+ "5ab77f5433c5d40ad448c16a": [
+  "FSG"
+ ],
+ "5ab77f5433c5d40ad448c16c": [
+  "FSG"
+ ],
+ "5ab77f5433c5d40ad448c17a": [
+  "ASPack"
+ ],
+ "5ab77f5433c5d40ad448c17b": [
+  "ASPack"
+ ],
+ "5ab77f5433c5d40ad448c1bc": [
+  "UPX"
+ ],
+ "5ab77f5433c5d40ad448c1c4": [
+  "ASPack"
+ ],
+ "5ab77f5433c5d40ad448c1cd": [
+  "UPX"
+ ],
+ "5ab77f5533c5d40ad448c1e3": [
+  "UPX"
+ ],
+ "5ab77f5533c5d40ad448c1f3": [],
+ "5ab77f5533c5d40ad448c1f6": [
+  "UPX"
+ ],
+ "5ab77f5533c5d40ad448c203": [
+  "FSG"
+ ],
+ "5ab77f5533c5d40ad448c208": [],
+ "5ab77f5533c5d40ad448c20c": [
+  "FSG"
+ ],
+ "5ab77f5533c5d40ad448c20d": [
+  "PECompact"
+ ],
+ "5ab77f5533c5d40ad448c221": [
+  "UPX"
+ ],
+ "5ab77f5533c5d40ad448c226": [
+  "UPX"
+ ],
+ "5ab77f5533c5d40ad448c22c": [
+  "UPX"
+ ],
+ "5ab77f5533c5d40ad448c237": [
+  "Enigma"
+ ],
+ "5ab77f5533c5d40ad448c240": [
+  "UPX"
+ ],
+ "5ab77f5533c5d40ad448c247": [
+  "UPX"
+ ],
+ "5ab77f5533c5d40ad448c25f": [],
+ "5ab77f5533c5d40ad448c26b": [
+  "UPX"
+ ],
+ "5ab77f5533c5d40ad448c26d": [
+  "UPX"
+ ],
+ "5ab77f5533c5d40ad448c26f": [
+  "UPX"
+ ],
+ "5ab77f5633c5d40ad448c271": [
+  "Dotfuscator"
+ ],
+ "5ab77f5633c5d40ad448c280": [],
+ "5ab77f5633c5d40ad448c287": [],
+ "5ab77f5633c5d40ad448c297": [
+  "Sixxpack"
+ ],
+ "5ab77f5633c5d40ad448c2a8": [
+  "Dotfuscator"
+ ],
+ "5ab77f5633c5d40ad448c2a9": [
+  "UPX"
+ ],
+ "5ab77f5633c5d40ad448c2aa": [
+  "UPX"
+ ],
+ "5ab77f5633c5d40ad448c2b1": [
+  "UPX"
+ ],
+ "5ab77f5633c5d40ad448c2de": [
+  "UPX"
+ ],
+ "5ab77f5633c5d40ad448c2ea": [
+  "UPX"
+ ],
+ "5ab77f5633c5d40ad448c2ec": [
+  "UPX"
+ ],
+ "5ab77f5633c5d40ad448c2ed": [
+  "UPX"
+ ],
+ "5ab77f5633c5d40ad448c305": [
+  "PE-PACK"
+ ],
+ "5ab77f5733c5d40ad448c311": [
+  "UPX"
+ ],
+ "5ab77f5733c5d40ad448c332": [],
+ "5ab77f5733c5d40ad448c335": [],
+ "5ab77f5733c5d40ad448c350": [
+  "UPX"
+ ],
+ "5ab77f5733c5d40ad448c368": [
+  "UPX"
+ ],
+ "5ab77f5733c5d40ad448c370": [
+  "UPX"
+ ],
+ "5ab77f5733c5d40ad448c37a": [],
+ "5ab77f5733c5d40ad448c38f": [
+  "UPX"
+ ],
+ "5ab77f5833c5d40ad448c3b7": [
+  "UPX"
+ ],
+ "5ab77f5833c5d40ad448c3be": [],
+ "5ab77f5833c5d40ad448c3c7": [
+  "UPX"
+ ],
+ "5ab77f5833c5d40ad448c3e6": [
+  "UPX"
+ ],
+ "5ab77f5833c5d40ad448c3e9": [
+  "UPX"
+ ],
+ "5ab77f5833c5d40ad448c3f2": [
+  "SmartAssembly"
+ ],
+ "5ab77f5833c5d40ad448c40c": [],
+ "5ab77f5833c5d40ad448c417": [
+  "UPX"
+ ],
+ "5ab77f5833c5d40ad448c419": [
+  "UPX"
+ ],
+ "5ab77f5833c5d40ad448c41b": [
+  "UPX"
+ ],
+ "5ab77f5833c5d40ad448c41e": [
+  "UPX"
+ ],
+ "5ab77f5933c5d40ad448c42e": [
+  "ARM Protector"
+ ],
+ "5ab77f5933c5d40ad448c44b": [
+  "UPX"
+ ],
+ "5ab77f5933c5d40ad448c44e": [
+  "UPX"
+ ],
+ "5ab77f5933c5d40ad448c459": [],
+ "5ab77f5933c5d40ad448c46f": [
+  "UPX"
+ ],
+ "5ab77f5933c5d40ad448c47a": [],
+ "5ab77f5933c5d40ad448c47c": [],
+ "5ab77f5933c5d40ad448c49c": [
+  "UPX"
+ ],
+ "5ab77f5933c5d40ad448c4a4": [
+  "Dotfuscator"
+ ],
+ "5ab77f5933c5d40ad448c4aa": [
+  "UPX"
+ ],
+ "5ab77f5933c5d40ad448c4ac": [
+  "UPX"
+ ],
+ "5ab77f5933c5d40ad448c4af": [
+  "UPX"
+ ],
+ "5ab77f5933c5d40ad448c4b9": [
+  "PECompact"
+ ],
+ "5ab77f5a33c5d40ad448c4d5": [
+  "UPX"
+ ],
+ "5ab77f5a33c5d40ad448c4d7": [
+  "UPX"
+ ],
+ "5ab77f5a33c5d40ad448c4dd": [
+  "UPX"
+ ],
+ "5ab77f5a33c5d40ad448c4e6": [
+  "ASPack"
+ ],
+ "5ab77f5a33c5d40ad448c4e7": [
+  "Enigma"
+ ],
+ "5ab77f5a33c5d40ad448c4ec": [
+  "UPX"
+ ],
+ "5ab77f5a33c5d40ad448c4f2": [
+  "UPX"
+ ],
+ "5ab77f5a33c5d40ad448c510": [
+  "UPX"
+ ],
+ "5ab77f5a33c5d40ad448c511": [
+  "UPX"
+ ],
+ "5ab77f5a33c5d40ad448c521": [
+  "PE-PACK",
+  "UPX"
+ ],
+ "5ab77f5a33c5d40ad448c541": [
+  "UPX"
+ ],
+ "5ab77f5b33c5d40ad448c55d": [
+  "ASPack"
+ ],
+ "5ab77f5b33c5d40ad448c562": [],
+ "5ab77f5b33c5d40ad448c565": [
+  "UPX"
+ ],
+ "5ab77f5b33c5d40ad448c567": [
+  "UPX"
+ ],
+ "5ab77f5b33c5d40ad448c56f": [
+  "UPX"
+ ],
+ "5ab77f5b33c5d40ad448c59b": [],
+ "5ab77f5b33c5d40ad448c5b4": [
+  "Enigma"
+ ],
+ "5ab77f5b33c5d40ad448c5df": [],
+ "5ab77f5b33c5d40ad448c5e0": [
+  "tElock"
+ ],
+ "5ab77f5b33c5d40ad448c5e2": [
+  "FSG"
+ ],
+ "5ab77f5b33c5d40ad448c5e6": [
+  "UPX"
+ ],
+ "5ab77f5b33c5d40ad448c5eb": [
+  "PE-PACK"
+ ],
+ "5ab77f5b33c5d40ad448c5ef": [
+  "PE-PACK"
+ ],
+ "5ab77f5c33c5d40ad448c5fe": [
+  "MEW"
+ ],
+ "5ab77f5c33c5d40ad448c5ff": [
+  "ARM Protector"
+ ],
+ "5ab77f5c33c5d40ad448c634": [
+  "tElock"
+ ],
+ "5ab77f5c33c5d40ad448c67e": [],
+ "5ab77f5d33c5d40ad448c697": [
+  "UPX"
+ ],
+ "5ab77f5d33c5d40ad448c6bb": [
+  "BJFnt"
+ ],
+ "5ab77f5d33c5d40ad448c6bc": [
+  "BJFnt"
+ ],
+ "5ab77f5d33c5d40ad448c6e7": [],
+ "5ab77f5d33c5d40ad448c701": [
+  "UPX"
+ ],
+ "5ab77f5d33c5d40ad448c702": [
+  "UPX"
+ ],
+ "5ab77f5e33c5d40ad448c717": [
+  "UPX"
+ ],
+ "5ab77f5e33c5d40ad448c724": [
+  "UPX"
+ ],
+ "5ab77f5e33c5d40ad448c76d": [
+  "UPX"
+ ],
+ "5ab77f5e33c5d40ad448c79d": [],
+ "5ab77f5f33c5d40ad448c7ac": [
+  "FSG"
+ ],
+ "5ab77f5f33c5d40ad448c7c1": [
+  "UPX"
+ ],
+ "5ab77f5f33c5d40ad448c7d3": [
+  "tElock"
+ ],
+ "5ab77f5f33c5d40ad448c7de": [
+  "UPX"
+ ],
+ "5ab77f5f33c5d40ad448c7ea": [
+  "MEW"
+ ],
+ "5ab77f5f33c5d40ad448c7f4": [
+  "FSG"
+ ],
+ "5ab77f5f33c5d40ad448c7f5": [
+  "FSG"
+ ],
+ "5ab77f5f33c5d40ad448c801": [
+  "UPX"
+ ],
+ "5ab77f5f33c5d40ad448c81f": [
+  "ASPack"
+ ],
+ "5ab77f5f33c5d40ad448c82f": [
+  "ASPack"
+ ],
+ "5ab77f6033c5d40ad448c83e": [
+  "FSG"
+ ],
+ "5ab77f6033c5d40ad448c840": [
+  "PECompact"
+ ],
+ "5ab77f6033c5d40ad448c841": [
+  "FSG"
+ ],
+ "5ab77f6033c5d40ad448c844": [
+  "UPX"
+ ],
+ "5ab77f6033c5d40ad448c847": [
+  "FSG"
+ ],
+ "5ab77f6033c5d40ad448c853": [
+  "UPX"
+ ],
+ "5ab77f6033c5d40ad448c860": [
+  "tElock"
+ ],
+ "5ab77f6033c5d40ad448c865": [
+  "UPX"
+ ],
+ "5ab77f6033c5d40ad448c871": [],
+ "5ab77f6033c5d40ad448c872": [],
+ "5ab77f6033c5d40ad448c879": [],
+ "5ab77f6033c5d40ad448c881": [
+  "UPX"
+ ],
+ "5ab77f6033c5d40ad448c884": [
+  "MEW"
+ ],
+ "5ab77f6033c5d40ad448c886": [
+  "UPX"
+ ],
+ "5ab77f6033c5d40ad448c887": [
+  "UPX"
+ ],
+ "5ab77f6033c5d40ad448c88b": [
+  "ASPack"
+ ],
+ "5ab77f6033c5d40ad448c894": [
+  "ASPack"
+ ],
+ "5ab77f6033c5d40ad448c8a4": [],
+ "5ab77f6033c5d40ad448c8ba": [],
+ "5ab77f6033c5d40ad448c8cf": [
+  "UPX"
+ ],
+ "5ab77f6133c5d40ad448c8d7": [],
+ "5ab77f6133c5d40ad448c8e4": [
+  "UPX"
+ ],
+ "5ab77f6133c5d40ad448c8fc": [
+  "UPX"
+ ],
+ "5ab77f6133c5d40ad448c934": [
+  "FSG"
+ ],
+ "5ab77f6133c5d40ad448c935": [
+  "UPX"
+ ],
+ "5ab77f6133c5d40ad448c950": [
+  "FSG"
+ ],
+ "5ab77f6133c5d40ad448c95b": [
+  "PE-PACK"
+ ],
+ "5ab77f6233c5d40ad448c96d": [
+  "FSG"
+ ],
+ "5ab77f6233c5d40ad448c96f": [
+  "ASPack"
+ ],
+ "5ab77f6233c5d40ad448c970": [
+  "UPX"
+ ],
+ "5ab77f6233c5d40ad448c972": [
+  "ASPack",
+  "UPX"
+ ],
+ "5ab77f6233c5d40ad448c973": [
+  "ASPack"
+ ],
+ "5ab77f6233c5d40ad448c976": [
+  "UPX"
+ ],
+ "5ab77f6233c5d40ad448c97c": [
+  "UPX"
+ ],
+ "5ab77f6233c5d40ad448c97e": [
+  "UPX"
+ ],
+ "5ab77f6233c5d40ad448c98b": [
+  "FSG"
+ ],
+ "5ab77f6233c5d40ad448c9ba": [
+  "UPX"
+ ],
+ "5ab77f6233c5d40ad448c9bb": [],
+ "5ab77f6333c5d40ad448ca13": [
+  "UPX"
+ ],
+ "5ab77f6333c5d40ad448ca14": [
+  "UPX"
+ ],
+ "5ab77f6333c5d40ad448ca24": [
+  "UPX"
+ ],
+ "5ab77f6333c5d40ad448ca2d": [
+  "UPX"
+ ],
+ "5ab77f6333c5d40ad448ca31": [
+  "UPX"
+ ],
+ "5ab77f6333c5d40ad448ca33": [
+  "UPX"
+ ],
+ "5ab77f6333c5d40ad448ca39": [
+  "PE-PACK"
+ ],
+ "5ab77f6333c5d40ad448ca3a": [],
+ "5ab77f6333c5d40ad448ca3c": [],
+ "5ab77f6333c5d40ad448ca5f": [
+  "FSG"
+ ],
+ "5ab77f6333c5d40ad448ca60": [
+  "UPX"
+ ],
+ "5ab77f6333c5d40ad448ca61": [
+  "UPX"
+ ],
+ "5ab77f6333c5d40ad448ca68": [],
+ "5ab77f6333c5d40ad448ca96": [
+  "UPX"
+ ],
+ "5ab77f6433c5d40ad448ca9b": [
+  "UPX"
+ ],
+ "5ab77f6433c5d40ad448ca9c": [
+  "UPX"
+ ],
+ "5ab77f6433c5d40ad448cab8": [
+  "FSG"
+ ],
+ "5ab77f6433c5d40ad448cac6": [
+  "PECompact"
+ ],
+ "5ab77f6433c5d40ad448caea": [
+  "FSG"
+ ],
+ "5ab77f6433c5d40ad448cb06": [],
+ "5ab77f6433c5d40ad448cb0b": [
+  "Confuser"
+ ],
+ "5ab77f6433c5d40ad448cb0d": [
+  "ASPack"
+ ],
+ "5ab77f6433c5d40ad448cb15": [],
+ "5ab77f6433c5d40ad448cb17": [],
+ "5ab77f6433c5d40ad448cb1d": [
+  "UPX"
+ ],
+ "5ab77f6433c5d40ad448cb23": [
+  "UPX"
+ ],
+ "5ab77f6433c5d40ad448cb28": [],
+ "5ab77f6533c5d40ad448cb38": [
+  "tElock"
+ ],
+ "5ab77f6533c5d40ad448cb39": [
+  "UPX"
+ ],
+ "5ab77f6533c5d40ad448cb3e": [
+  "UPX"
+ ],
+ "5ab77f6533c5d40ad448cb81": [
+  "UPX"
+ ],
+ "5ab77f6533c5d40ad448cb83": [
+  "PE-PACK"
+ ],
+ "5ab77f6533c5d40ad448cb8d": [
+  "Petite"
+ ],
+ "5ab77f6533c5d40ad448cb92": [
+  "UPX"
+ ],
+ "5ab77f6533c5d40ad448cba9": [
+  "UPX"
+ ],
+ "5ab77f6633c5d40ad448cbd2": [
+  "ARM Protector"
+ ],
+ "5ab77f6633c5d40ad448cbe5": [
+  "UPX"
+ ],
+ "5ab77f6633c5d40ad448cbe8": [
+  "ARM Protector"
+ ],
+ "5ab77f6633c5d40ad448cbf1": [],
+ "5ab77f6633c5d40ad448cc12": [
+  "ARM Protector"
+ ],
+ "5ab77f6633c5d40ad448cc1e": [
+  "Petite"
+ ],
+ "5ab77f6633c5d40ad448cc23": [
+  "UPX"
+ ],
+ "5ab77f6633c5d40ad448cc27": [],
+ "5ab77f6633c5d40ad448cc2e": [],
+ "5ab77f6633c5d40ad448cc33": [
+  "UPX"
+ ],
+ "5ab77f6633c5d40ad448cc37": [
+  "UPX"
+ ],
+ "5ab77f6633c5d40ad448cc4d": [
+  "UPX"
+ ],
+ "5ab77f6633c5d40ad448cc5b": [
+  "UPX"
+ ],
+ "5ab77f6633c5d40ad448cc60": [],
+ "5ab77f6733c5d40ad448cc6e": [
+  "Petite"
+ ],
+ "5ac58d7333c5d42f34b18081": [
+  "UPX"
+ ],
+ "5b58ebc433c5d46b771434a7": [
+  "UPX"
+ ],
+ "5c0da25633c5d41e58e00557": [
+  "UPX"
+ ],
+ "5d12784f33c5d41c6d56e1a6": [
+  "Babel .NET",
+  "ConfuserEx",
+  "Goliath"
+ ],
+ "5f2eea5433c5d42a7c667c48": [
+  "UPX"
+ ],
+ "5f7230a133c5d4357b3b0339": [
+  "UPX"
+ ],
+ "5f7237e933c5d4357b3b033b": [
+  "UPX"
+ ],
+ "5fd6173633c5d424269a1b81": [
+  "Confuser",
+  "Dotfuscator",
+  "Goliath"
+ ],
+ "5fe0bfef33c5d4264e590068": [
+  "Confuser",
+  "ConfuserEx"
+ ],
+ "5fe5ed8633c5d4264e5900d9": [
+  "UPX"
+ ],
+ "60a20ac633c5d4544d40d6ca": [],
+ "60be2a6033c5d410b8842c91": [
+  "UPX"
+ ],
+ "6139ecce33c5d4649c52b980": [
+  "Babel .NET",
+  "Dotfuscator",
+  "Goliath",
+  "Yano"
+ ],
+ "619a59ba33c5d455dece61e3": [
+  "SmartAssembly"
+ ],
+ "61d6581033c5d413767ca32f": [
+  "SmartAssembly"
+ ],
+ "623f6cd033c5d46c8bcc055d": [
+  "Babel .NET",
+  "Yano"
+ ],
+ "6260362133c5d42a191a5d2e": [
+  "Babel .NET",
+  "Confuser",
+  "Goliath",
+  "Yano"
+ ],
+ "62bb2f0933c5d4251e723a46": [
+  "PyInstaller"
+ ],
+ "62cd5ccc33c5d44a934e9750": [],
+ "631b0da633c5d4425e2cd2a3": [
+  "Babel .NET",
+  "Confuser",
+  "Goliath",
+  "Sixxpack",
+  "Yano"
+ ],
+ "64216f6833c5d447bc761e17": [
+  "UPX"
+ ],
+ "6431261633c5d439389125dc": [],
+ "6442366033c5d43938912a85": [],
+ "6442408433c5d43938912a8b": [
+  "UPX"
+ ],
+ "6445638133c5d43938912b2d": [],
+ "648cb13133c5d4393891396a": [],
+ "64fd7a44d931496abf909925": [
+  "UPX"
+ ],
+ "6574682835240bf986f0ffb5": [
+  "UPX"
+ ],
+ "664a153e6b8bd8ddfe33cc66": [
+  "UPX"
+ ],
+ "665bcbdbe7b35c09bb2666a4": [
+  "Confuser",
+  "ConfuserEx"
+ ],
+ "6675db88e7b35c09bb26703c": [
+  "Confuser"
+ ],
+ "668329cd262e4555f2062b5c": [
+  "UPX"
+ ],
+ "66a3df9e90c4c2830c8210fa": [
+  "UPX"
+ ],
+ "66ce5d65b899a3b9dd02b12e": [
+  "UPX"
+ ],
+ "670e2b1f9b533b4c22bd1441": [
+  "Babel .NET",
+  "Confuser",
+  "Goliath",
+  "Sixxpack",
+  "Yano"
+ ],
+ "673ff5da9b533b4c22bd2fff": [
+  "UPX"
+ ],
+ "67f266e99397ab808f9ae34a": [
+  "PECompact"
+ ],
+ "68ff92e62d267f28f69b78f1": [
+  "UPX"
+ ],
+ "6976041d9bf7b8997653a6cf": [
+  "PyInstaller"
+ ],
+ "69917e2d853c2615340abd81": [
+  "Confuser"
+ ],
+ "699da9a00b6d36e727710a49": [],
+ "69a65b6c7a778cfffbfb680e": [
+  "PyInstaller"
+ ],
+ "6a4014135f26f108ba18ba0b": [
+  "PyInstaller"
+ ]
+}


### PR DESCRIPTION
## What
Adds `script/import_packer_tags.py` — the **safe, incremental** way to import the DIE-detected packer labels (from dataset PRs #2 + #3) into the live DB, plus `script/packer_tags.json` (256 crackmes → `{hexid: [packer names]}`).

## Why not just re-run `sync_tags.py`?
`sync_tags.py` is **authoritative**: Phase 2 does `crackme.update_many({}, {"$set": {"tags": []}})` then rewrites tags from the dataset. Re-running it would wipe manual tag edits made since the initial import, blank tags on crackmes uploaded after the dump, and replace the whole vocabulary doc. Not safe for an incremental import.

## What this does instead (all additive)
- **Phase A — vocabulary:** `$addToSet` the packer sub-labels into the existing `tag_vocabulary` doc (6 new: ARM Protector, BJFnt, Confuser, PE-PACK, PyInstaller, Sixxpack). Existing entries untouched.
- **Phase B — crackme tags:** for each affected crackme, `$addToSet` `Packer` + its specific packer name(s). **Never removes a tag; never touches any other crackme**, so manual edits are preserved. 200 get `Packer` + a name, 56 get generic `Packer` only (reliable-but-obscure, suspect virtualizers, or files with multiple detected packers where the specific identity is unreliable).

Same conventions as `apply_download_counts.py` (config/config.json, dry-run default, `--apply`), lightweight (only `pymongo`), and **idempotent**. Verified with mongomock that manual tags are preserved and non-target crackmes are untouched.

## Run
```
cd script
python import_packer_tags.py            # dry run
python import_packer_tags.py --apply    # apply, then restart app workers
```

Note: assumes a `tag_vocabulary` doc exists (it does if `sync_tags.py --apply` ran); otherwise it warns and skips the vocab phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)