### PR TITLE
Add a link to the site home page from the review tool (#165)

### DIFF
--- a/review/templates/reviewer/dashboard.html
+++ b/review/templates/reviewer/dashboard.html
@@ -18,6 +18,7 @@
             <h2>Welcome, {{ user }}!{% if is_admin %} (Admin){% endif %}</h2>
         </section>
         <section class="navbar-section">
+            <a href="/" class="btn btn-link">crackmes.one</a>
             <a href="{{ url_for('reviewer.logout') }}" class="btn btn-link">Logout</a>
         </section>
     </header>

--- a/review/templates/reviewer/delcomment.html
+++ b/review/templates/reviewer/delcomment.html
@@ -18,6 +18,7 @@
             <h2>Welcome, {{ user }}!{% if is_admin %} (Admin){% endif %}</h2>
         </section>
         <section class="navbar-section">
+            <a href="/" class="btn btn-link">crackmes.one</a>
             <a href="{{ url_for('reviewer.logout') }}" class="btn btn-link">Logout</a>
         </section>
     </header>

--- a/review/templates/reviewer/delcrackme.html
+++ b/review/templates/reviewer/delcrackme.html
@@ -26,6 +26,7 @@
             <h2>Welcome, {{ user }}!{% if is_admin %} (Admin){% endif %}</h2>
         </section>
         <section class="navbar-section">
+            <a href="/" class="btn btn-link">crackmes.one</a>
             <a href="{{ url_for('reviewer.logout') }}" class="btn btn-link">Logout</a>
         </section>
     </header>

--- a/review/templates/reviewer/deleteuser.html
+++ b/review/templates/reviewer/deleteuser.html
@@ -55,6 +55,7 @@
             <h2>Welcome, {{ user }}!{% if is_admin %} (Admin){% endif %}</h2>
         </section>
         <section class="navbar-section">
+            <a href="/" class="btn btn-link">crackmes.one</a>
             <a href="{{ url_for('reviewer.logout') }}" class="btn btn-link">Logout</a>
         </section>
     </header>

--- a/review/templates/reviewer/delsolution.html
+++ b/review/templates/reviewer/delsolution.html
@@ -18,6 +18,7 @@
             <h2>Welcome, {{ user }}!{% if is_admin %} (Admin){% endif %}</h2>
         </section>
         <section class="navbar-section">
+            <a href="/" class="btn btn-link">crackmes.one</a>
             <a href="{{ url_for('reviewer.logout') }}" class="btn btn-link">Logout</a>
         </section>
     </header>

--- a/review/templates/reviewer/editcrackme.html
+++ b/review/templates/reviewer/editcrackme.html
@@ -18,6 +18,7 @@
             <h2>Welcome, {{ user }}!{% if is_admin %} (Admin){% endif %}</h2>
         </section>
         <section class="navbar-section">
+            <a href="/" class="btn btn-link">crackmes.one</a>
             <a href="{{ url_for('reviewer.logout') }}" class="btn btn-link">Logout</a>
         </section>
     </header>

--- a/review/templates/reviewer/labelrequests.html
+++ b/review/templates/reviewer/labelrequests.html
@@ -18,6 +18,7 @@
             <h2>Welcome, {{ user }}!{% if is_admin %} (Admin){% endif %}</h2>
         </section>
         <section class="navbar-section">
+            <a href="/" class="btn btn-link">crackmes.one</a>
             <a href="{{ url_for('reviewer.logout') }}" class="btn btn-link">Logout</a>
         </section>
     </header>

--- a/review/templates/reviewer/lookupuser.html
+++ b/review/templates/reviewer/lookupuser.html
@@ -99,6 +99,7 @@
             <h2>Welcome, {{ user }}!{% if is_admin %} (Admin){% endif %}</h2>
         </section>
         <section class="navbar-section">
+            <a href="/" class="btn btn-link">crackmes.one</a>
             <a href="{{ url_for('reviewer.logout') }}" class="btn btn-link">Logout</a>
         </section>
     </header>

--- a/review/templates/reviewer/managereviewers.html
+++ b/review/templates/reviewer/managereviewers.html
@@ -96,6 +96,7 @@
             <h2>Welcome, {{ user }}!{% if is_admin %} (Admin){% endif %}</h2>
         </section>
         <section class="navbar-section">
+            <a href="/" class="btn btn-link">crackmes.one</a>
             <a href="{{ url_for('reviewer.logout') }}" class="btn btn-link">Logout</a>
         </section>
     </header>

--- a/review/templates/reviewer/resetuserpassword.html
+++ b/review/templates/reviewer/resetuserpassword.html
@@ -18,6 +18,7 @@
             <h2>Welcome, {{ user }}!{% if is_admin %} (Admin){% endif %}</h2>
         </section>
         <section class="navbar-section">
+            <a href="/" class="btn btn-link">crackmes.one</a>
             <a href="{{ url_for('reviewer.logout') }}" class="btn btn-link">Logout</a>
         </section>
     </header>

--- a/review/templates/reviewer/reviewcrackme.html
+++ b/review/templates/reviewer/reviewcrackme.html
@@ -18,6 +18,7 @@
             <h2>Welcome, {{ user }}!{% if is_admin %} (Admin){% endif %}</h2>
         </section>
         <section class="navbar-section">
+            <a href="/" class="btn btn-link">crackmes.one</a>
             <a href="{{ url_for('reviewer.logout') }}" class="btn btn-link">Logout</a>
         </section>
     </header>

--- a/review/templates/reviewer/reviewsolution.html
+++ b/review/templates/reviewer/reviewsolution.html
@@ -18,6 +18,7 @@
             <h2>Welcome, {{ user }}!{% if is_admin %} (Admin){% endif %}</h2>
         </section>
         <section class="navbar-section">
+            <a href="/" class="btn btn-link">crackmes.one</a>
             <a href="{{ url_for('reviewer.logout') }}" class="btn btn-link">Logout</a>
         </section>
     </header>

--- a/review/templates/reviewer/sitearchive.html
+++ b/review/templates/reviewer/sitearchive.html
@@ -18,6 +18,7 @@
             <h2>Welcome, {{ user }}!{% if is_admin %} (Admin){% endif %}</h2>
         </section>
         <section class="navbar-section">
+            <a href="/" class="btn btn-link">crackmes.one</a>
             <a href="{{ url_for('reviewer.logout') }}" class="btn btn-link">Logout</a>
         </section>
     </header>

--- a/review/templates/reviewer/viewcrackme.html
+++ b/review/templates/reviewer/viewcrackme.html
@@ -18,6 +18,7 @@
             <h2>Welcome, {{ user }}!{% if is_admin %} (Admin){% endif %}</h2>
         </section>
         <section class="navbar-section">
+            <a href="/" class="btn btn-link">crackmes.one</a>
             <a href="{{ url_for('reviewer.logout') }}" class="btn btn-link">Logout</a>
         </section>
     </header>

--- a/review/templates/reviewer/viewsolution.html
+++ b/review/templates/reviewer/viewsolution.html
@@ -21,6 +21,7 @@
             <h2>Welcome, {{ user }}!{% if is_admin %} (Admin){% endif %}</h2>
         </section>
         <section class="navbar-section">
+            <a href="/" class="btn btn-link">crackmes.one</a>
             <a href="{{ url_for('reviewer.logout') }}" class="btn btn-link">Logout</a>
         </section>
     </header>


### PR DESCRIPTION
Closes #165.

The review tool pages had no way to navigate back to the public site — reviewers had to manually edit the URL. This adds a **crackmes.one** link to the reviewer navbar, placed right before the existing **Logout** button.

## Changes
- Added `<a href="/" class="btn btn-link">crackmes.one</a>` to the navbar `navbar-section` on all 15 review-tool templates that render the header (`login.html` is untouched since it has no navbar).

Since the reviewer is a blueprint mounted at `/review` on the same app, `/` points at the public home page (matching the pattern already used in `templates/partial/menu.html`).

## Testing
- Templates only; verified exactly one link inserted per navbar template with consistent indentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)